### PR TITLE
Add streaming JSON functionality.

### DIFF
--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -71,6 +71,15 @@ locale, and if that doesn't exist either to English.
 
 Print results as JSON instead of human language.
 
+=item --json_stream
+
+Stream the results as JSON objects, useful to follow the progress in a machine
+readable way.
+
+=item --json_translate
+
+For streaming JSON output, include the translated message of the tag.
+
 =item --raw, --no-raw
 
 Print messages as raw dumps instead of passing them through the translation


### PR DESCRIPTION
This added the functionality to stream the results as JSON objects which can be used by other programs to follow the progress in a machine readable way.

```
$ zonemaster-cli --json_translate --json_stream --level DEBUG --no-ipv6 example.com
{"args":{"string":"2015-10-16 11:15:45 +0000","time_t":"1444994145"},"level":"DEBUG","message":"SYSTEM:START_TIME string=2015-10-16 11:15:45 +0000, time_t=1444994145","module":"SYSTEM","tag":"START_TIME","timestamp":6.69956207275391e-05}
{"args":{"module":"all","zone":"example.com"},"level":"DEBUG","message":"SYSTEM:TEST_TARGET module=all, zone=example.com","module":"SYSTEM","tag":"TEST_TARGET","timestamp":0.000236988067626953}
...
{"args":{"mname":"sns.dns.icann.org"},"level":"INFO","message":"SOA 'mname' value (sns.dns.icann.org) refers to a NS which is not an alias (CNAME).","module":"ZONE","tag":"MNAME_IS_NOT_CNAME","timestamp":15.9097239971161}
{"args":{"mname":"sns.dns.icann.org"},"level":"INFO","message":"SOA 'mname' value (sns.dns.icann.org) refers to a NS which is not an alias (CNAME).","module":"ZONE","tag":"MNAME_IS_NOT_CNAME","timestamp":15.9366610050201}
{"args":{},"level":"DEBUG","message":"MX record for the domain is not pointing to a CNAME.","module":"ZONE","tag":"MX_RECORD_IS_NOT_CNAME","timestamp":15.9370710849762}
{"args":{"info":"A=93.184.216.34/AAAA=2606:2800:220:1:248:1893:25c8:1946"},"level":"INFO","message":"Target (A=93.184.216.34/AAAA=2606:2800:220:1:248:1893:25c8:1946) found to deliver e-mail for the domain name.","module":"ZONE","tag":"MX_RECORD_EXISTS","timestamp":15.9692349433899}
{"args":{"module":"Zonemaster::Test::Zone"},"level":"DEBUG","message":"Module Zonemaster::Test::Zone finished running.","module":"SYSTEM","tag":"MODULE_END","timestamp":15.9694418907166}
```