### PR TITLE
Better way to check ExtUtils::MakeMaker version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ build_requires( 'Test::More' => 0, );
 
 # Dirty hack to avoid complaints about unparsable version number from
 # old versions of ExtUtils::MakeMaker.
-if ( ExtUtils::MakeMaker->VERSION >= 6.68 ) {
+if ( eval { ExtUtils::MakeMaker->VERSION(6.68) } ) {
     requires 'Zonemaster' => 'v1.0.4';
 }
 else {


### PR DESCRIPTION
`UNIVERSAL::VERSION()` returns a string of the version and the version may not be all numeric so its better to let the function check for the minimum version.