### PR TITLE
Move license from Makefile.PL to main module

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,15 +6,13 @@ use inc::Module::Install;
 use ExtUtils::MakeMaker ();
 
 name 'Zonemaster-CLI';
-license 'bsd';
 all_from 'lib/Zonemaster/CLI.pm';
-
-tests_recursive( 't' );
-
 resources(
     repository => 'https://github.com/dotse/zonemaster-cli',
     bugtracker => 'https://github.com/dotse/zonemaster-cli/issues',
 );
+
+tests_recursive( 't' );
 
 configure_requires( 'Locale::Msgfmt' => 0.15, );
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -647,3 +647,14 @@ Vincent Levigneron <vincent.levigneron at nic.fr>
 
 Calle Dybedahl <calle at init.se>
 - Original author
+
+=head1 LICENSE
+
+This is free software, licensed under:
+
+The (three-clause) BSD License
+
+The full text of the license can be found in the
+F<LICENSE> file included with this distribution.
+
+=cut


### PR DESCRIPTION
Aims to fix [CPANTS errors](https://cpants.cpanauthors.org/release/ZNMSTR/Zonemaster-CLI-v1.1.2) has_license_in_source_file and has_known_license_in_source_file.