### PR TITLE
Update option 'list_tests'

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -30,7 +30,7 @@ use Zonemaster::Engine;
 use Zonemaster::Engine::Exception;
 use Zonemaster::Engine::Logger::Entry;
 use Zonemaster::Engine::Translator;
-use Zonemaster::Engine::Util qw[parse_hints pod_extract_for];
+use Zonemaster::Engine::Util qw[parse_hints];
 use Zonemaster::Engine::Zone;
 use Zonemaster::LDNS;
 
@@ -841,19 +841,8 @@ sub print_test_list {
 
     foreach my $module ( sort keys %methods ) {
         say $module;
-        my $doc = pod_extract_for( $module );
         foreach my $method ( sort @{ $methods{$module} } ) {
-            printf "  %${maxlen}s ", $method;
-            if ( $doc and $doc->{$method} ) {
-                print reflow_string(
-                    $doc->{$method},
-                    optimum => 65,
-                    maximum => 75,
-                    indent1 => '   ',
-                    indent2 => ( ' ' x ( $maxlen + 6 ) )
-                );
-            }
-            print "\n";
+            printf "  %${maxlen}s\n", $method;
         }
         print "\n";
     }


### PR DESCRIPTION
## Purpose

This PR updates option `list_tests` by removing the use of the POD extraction function ([Zonemaster::Engine::Util/pod_extract_for()](https://github.com/zonemaster/zonemaster-engine/blob/v4.7.3/lib/Zonemaster/Engine/Util.pm#L132-L141)) of Test Case methods.
This is no longer useful after the changes in https://github.com/zonemaster/zonemaster-engine/pull/1277, where that function is removed (by commit https://github.com/zonemaster/zonemaster-engine/commit/0631ee043bf2b1541e00922783c142a2573e1a00). See [comment](https://github.com/zonemaster/zonemaster-engine/pull/1277#issuecomment-1715769188).

## Context

Relates to https://github.com/zonemaster/zonemaster-engine/pull/1277 (specifically commit https://github.com/zonemaster/zonemaster-engine/commit/0631ee043bf2b1541e00922783c142a2573e1a00)

## Changes

`lib/Zonemaster/CLI.pm`

## How to test this PR

Run `zonemaster-cli --list_tests` and check that only the Test Cases IDs are outputted.