### PR TITLE
Use Zonemaster::Engine::Normalization module for input name normalization

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,8 @@ tests_recursive( 't' );
 # (see Zonemaster::LDNS below)
 
 requires(
+    'Readonly'           => 0,
+    'Net::IP::XS'        => 0,
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,
     'MooseX::Getopt'     => 0,


### PR DESCRIPTION
## Purpose

This PR introduces the usage of the [Zonemaster::Engine::Normalization](https://github.com/zonemaster/zonemaster-engine/blob/v4.7.3/lib/Zonemaster/Engine/Normalization.pm) module for input DNS name normalization.
It also adds input validation to the `--ns` argument..

## Context

The current specification can found [here](https://github.com/zonemaster/zonemaster/blob/v2023.1.4/docs/public/specifications/tests/RequirementsAndNormalizationOfDomainNames.md), and will replace the [Basic00](https://github.com/zonemaster/zonemaster/blob/v2023.1.4/docs/public/specifications/tests/Basic-TP/basic00.md) Test Case.

## Changes

- Make use of `Zonemaster::Engine::Normalization::normalize_name()`
- Significantly improve `--ns` argument validation:
   - Add check for several slash (`/`) characters
   - Add IP address validation which leverages both regex checks and `Net::IP::XS::Error()` for detailed error messages 
- Remove `Zonemaster::CLI::to_idn()`
- List `Readonly` and `Net::IP::XS` as direct dependencies

## How to test this PR

Testing should proceed as before, although more errors are now supported and several can be reported simultaneously:

```
$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 '@.İabcİ.İcc'
Ambiguous downcaseing of character "LATIN CAPITAL LETTER I WITH DOT ABOVE" in the domain name. Use all lower case instead.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01
Must give the name of a domain to test.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 ''
Must give the name of a domain to test.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 ' '
Domain name is empty.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 ' @!.'
Domain name has an ASCII label ("@!") with a character not permitted.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 zonemaster.net --ns 'ns1/.zonemaster.net/10.0.0.1'
--ns must be a name or a name/ip pair.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 zonemaster.net --ns 'ns1.zonemaster.net/1'
Invalid IP address in --ns argument.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 zonemaster.net --ns 'ns1.zonemaster.net/10.0.0.Z'
Invalid IP address in --ns argument:
        Invalid chars in IP 10.0.0.Z
        
$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 zonemaster.net --ns 'ns1.zonemaster.net/fe10:::'
Invalid IP address in --ns argument:
        Invalid address fe10::: (More than one :: pattern)

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 zonemaster.net --ns 'ns1@.zonemaster@.net!.'
Invalid name in --ns argument:
        Domain name has an ASCII label ("ns1@") with a character not permitted.
        Domain name has an ASCII label ("zonemaster@") with a character not permitted.
        Domain name has an ASCII label ("net!") with a character not permitted.

$ zonemaster-cli --show-testcase --no-ipv6 --test basic/basic01 zonemaster.net --ns 'ns1.zonemaster.net' --ns 'ns2.zonemaster.net/10.0.0.2' --ns 'ns3@.zonemaster.!net.'
Invalid name in --ns argument:
        Domain name has an ASCII label ("ns3@") with a character not permitted.
        Domain name has an ASCII label ("!net") with a character not permitted.
```

Examples of (in)valid domain names can be found in the [t/normalization.t unit test file in Engine](https://github.com/zonemaster/zonemaster-engine/blob/v4.7.3/t/normalization.t), e.g:

```
#Valid
example。com.
café.example.com

#Invalid
example。.com.
bad:%;!$.example.com.
❤️．example．com
```
