### PR TITLE
More flexible --test option

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,7 @@ inc/Module/Install/Share.pm
 inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
 lib/Zonemaster/CLI.pm
+lib/Zonemaster/CLI/TestCaseSet.pm
 LICENSE
 Makefile.PL
 MANIFEST			This list of files
@@ -29,6 +30,7 @@ share/locale/sl/LC_MESSAGES/Zonemaster-CLI.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-CLI.mo
 t/00-load.t
 t/pod.t
+t/test_case_set.t
 t/usage.fake-data.data
 t/usage.fake-root.data
 t/usage.hints

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -262,9 +262,10 @@ sub run {
     }
 
     {
-        my $cases = Zonemaster::CLI::TestCaseSet->new(
+        my %all_methods = Zonemaster::Engine->all_methods;
+        my $cases       = Zonemaster::CLI::TestCaseSet->new(    #
             Zonemaster::Engine::Profile->effective->get( q{test_cases} ),
-            Zonemaster::Engine->all_methods,
+            \%all_methods,
         );
 
         for my $test ( @opt_test ) {

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -28,14 +28,15 @@ use Readonly;
 use Scalar::Util qw[blessed];
 use Time::HiRes;
 use Try::Tiny;
-use Zonemaster::LDNS;
-use Zonemaster::Engine;
+use Zonemaster::CLI::TestCaseSet;
 use Zonemaster::Engine::Exception;
-use Zonemaster::Engine::Normalization qw[normalize_name];
 use Zonemaster::Engine::Logger::Entry;
+use Zonemaster::Engine::Normalization qw[normalize_name];
 use Zonemaster::Engine::Translator;
 use Zonemaster::Engine::Util       qw[parse_hints];
 use Zonemaster::Engine::Validation qw[validate_ipv4 validate_ipv6];
+use Zonemaster::Engine;
+use Zonemaster::LDNS;
 
 our %numeric = Zonemaster::Engine::Logger::Entry->levels;
 our $JSON    = JSON::XS->new->allow_blessed->convert_blessed->canonical;
@@ -169,7 +170,8 @@ sub run {
         $ENV{LC_ALL} = $opt_locale;
     }
 
-# Set LC_MESSAGES and LC_CTYPE separately (https://www.gnu.org/software/gettext/manual/html_node/Triggering.html#Triggering)
+    # Set LC_MESSAGES and LC_CTYPE separately
+    # (https://www.gnu.org/software/gettext/manual/html_node/Triggering.html#Triggering)
     if ( not defined setlocale( LC_MESSAGES, "" ) ) {
         my $locale = ( $ENV{LANGUAGE} || $ENV{LC_ALL} || $ENV{LC_MESSAGES} );
         say STDERR __x(
@@ -259,102 +261,27 @@ sub run {
         };
     }
 
-    my @testing_suite;
-    if ( @opt_test ) {
-        my %existing_tests        = Zonemaster::Engine->all_methods;
-        my @existing_test_modules = keys %existing_tests;
-        my @existing_test_cases   = map { @{ $existing_tests{$_} } } @existing_test_modules;
+    {
+        my $cases = Zonemaster::CLI::TestCaseSet->new(
+            Zonemaster::Engine::Profile->effective->get( q{test_cases} ),
+            Zonemaster::Engine->all_methods,
+        );
 
-        foreach my $t ( @opt_test ) {
-            # There should be at most one slash character
-            if ( $t =~ tr/\/// > 1 ) {
-                say STDERR __x(
-                    "Error: Invalid input '{cli_arg}' in --test. There must be at most one slash ('/') character.",
-                    cli_arg => $t );
-                return $EXIT_USAGE_ERROR;
-            }
+        for my $test ( @opt_test ) {
+            my @modifiers = Zonemaster::CLI::TestCaseSet->parse_modifier_expr( $test );
+            while ( @modifiers ) {
+                my $op   = shift @modifiers;
+                my $term = shift @modifiers;
 
-            # The case does not matter
-            $t = lc( $t );
-
-            my ( $module, $method );
-# Fully qualified module and test case (e.g. Example/example12), or just a test case (e.g. example12). Note the different capturing order.
-            if (   ( ( $module, $method ) = $t =~ m#^ ( [a-z]+ ) / ( [a-z]+[0-9]{2} ) $#ix )
-                or ( ( $method, $module ) = $t =~ m#^ ( ( [a-z]+ ) [0-9]{2} ) $#ix ) )
-            {
-                # Check that test module exists
-                if ( grep( /^$module$/, map { lc( $_ ) } @existing_test_modules ) ) {
-                    # Check that test case exists
-                    if ( grep( /^$method$/, @existing_test_cases ) ) {
-                        push @testing_suite, "$module/$method";
-                    }
-                    else {
-                        say STDERR __x(
-"Error: Unrecognized test case '{testcase}' in --test. Use --list-tests for a list of valid choices.",
-                            testcase => $method
-                        );
-                        return $EXIT_USAGE_ERROR;
-                    }
-                }
-                else {
-                    say STDERR __x(
-"Error: Unrecognized test module '{module}' in --test. Use --list-tests for a list of valid choices.",
-                        module => $module
-                    );
-                    return $EXIT_USAGE_ERROR;
-                }
-            } ## end if ( ( ( $module, $method...)))
-            # Just a module name (e.g. Example) or something invalid.
-            else {
-                $t =~ s{/$}{};
-                # Check that test module exists
-                if ( grep( /^$t$/, map { lc( $_ ) } @existing_test_modules ) ) {
-                    push @testing_suite, $t;
-                }
-                else {
-                    say STDERR __x( "Error: Invalid input '{cli_arg}' in --test.", cli_arg => $t );
+                if ( !$cases->apply_modifier( $op, $term ) ) {
+                    say STDERR __x( "Error: Unrecognized term '$term' in --test.\n" );
                     return $EXIT_USAGE_ERROR;
                 }
             }
-        } ## end foreach my $t ( @opt_test )
-
-        # Start with all profile-enabled test cases
-        my @actual_test_cases = @{ Zonemaster::Engine::Profile->effective->get( 'test_cases' ) };
-
-        # Derive test module from each profile-enabled test case
-        my %actual_test_modules;
-        foreach my $t ( @actual_test_cases ) {
-            my ( $module ) = $t =~ m#^ ( [a-z]+ ) [0-9]{2} $#ix;
-            $actual_test_modules{$module} = 1;
         }
 
-        # Check if more test cases need to be included in the profile
-        foreach my $t ( @testing_suite ) {
-            # Either a module/method, or just a module
-            my ( $module, $method ) = split( '/', $t );
-            if ( $method ) {
-                # Test case in not already in the profile, we add it explicitly and notify the user
-                if ( not grep( /^$method$/, @actual_test_cases ) ) {
-                    say $fh_diag __x(
-                        "Notice: Engine does not have test case '{testcase}' enabled in the profile. Forcing...",
-                        testcase => $method );
-                    push @actual_test_cases, $method;
-                }
-            }
-            else {
-                # No test case from this module is already in the profile, we can add them all
-                if ( not grep( /^$module$/, keys %actual_test_modules ) ) {
-                    # Get the test module with the right case
-                    ( $module ) = grep { lc( $module ) eq lc( $_ ) } @existing_test_modules;
-                    # No need to bother to check for duplicates here
-                    push @actual_test_cases, @{ $existing_tests{$module} };
-                }
-            }
-        } ## end foreach my $t ( @testing_suite)
-
-        # Configure Engine to include all of the required test cases in the profile
-        Zonemaster::Engine::Profile->effective->set( 'test_cases', [ uniq sort @actual_test_cases ] );
-    } ## end if ( @opt_test )
+        Zonemaster::Engine::Profile->effective->set( q{test_cases}, [ $cases->to_list ] ),
+    }
 
     # These two must come after any profile from command line has been loaded
     # to make any IPv4/IPv6 option override the profile setting.
@@ -642,29 +569,7 @@ sub run {
     Zonemaster::Engine->logger->callback( $message_printer );
 
     # Actually run tests!
-    eval {
-        if ( @opt_test ) {
-            foreach my $t ( @testing_suite ) {
-                # Either a module/method, or just a module
-                my ( $module, $method ) = split( '/', $t );
-                if ( $method ) {
-                    Zonemaster::Engine->test_method( $module, $method, $domain );
-                }
-                else {
-                    Zonemaster::Engine->test_module( $module, $domain );
-                }
-            }
-        }
-        else {
-            Zonemaster::Engine->test_zone( $domain );
-        }
-    };
-
-    if ( not $opt_raw and not $opt_json ) {
-        if ( not $printed_something ) {
-            say __( "Looks OK." );
-        }
-    }
+    eval { Zonemaster::Engine->test_zone( $domain ); };
 
     if ( $@ ) {
         my $err = $@;
@@ -673,6 +578,12 @@ sub run {
         }
         else {
             die $err;    # Don't know what it is, rethrow
+        }
+    }
+
+    if ( not $opt_raw and not $opt_json ) {
+        if ( not $printed_something ) {
+            say __( "Looks OK." );
         }
     }
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -34,7 +34,7 @@ use Zonemaster::Engine::Exception;
 use Zonemaster::Engine::Normalization qw[normalize_name];
 use Zonemaster::Engine::Logger::Entry;
 use Zonemaster::Engine::Translator;
-use Zonemaster::Engine::Util qw[parse_hints];
+use Zonemaster::Engine::Util       qw[parse_hints];
 use Zonemaster::Engine::Validation qw[validate_ipv4 validate_ipv6];
 
 our %numeric = Zonemaster::Engine::Logger::Entry->levels;
@@ -142,10 +142,11 @@ sub run {
             'test=s'          => \@opt_test,
             'time!'           => \$opt_time,
             'version!'        => \$opt_version,
-        ) or do {
+          )
+          or do {
             my_pod2usage( verbosity => 0, output => \*STDERR );
             return 2;
-        };
+          };
     }
 
     if ( $opt_help ) {
@@ -168,17 +169,19 @@ sub run {
         $ENV{LC_ALL} = $opt_locale;
     }
 
-    # Set LC_MESSAGES and LC_CTYPE separately (https://www.gnu.org/software/gettext/manual/html_node/Triggering.html#Triggering)
+# Set LC_MESSAGES and LC_CTYPE separately (https://www.gnu.org/software/gettext/manual/html_node/Triggering.html#Triggering)
     if ( not defined setlocale( LC_MESSAGES, "" ) ) {
-        my $locale = ($ENV{LANGUAGE} || $ENV{LC_ALL} || $ENV{LC_MESSAGES});
-        say STDERR __x( "Warning: setting locale category LC_MESSAGES to {locale} failed -- is it installed on this system?\n\n",
-                        locale => $locale)
+        my $locale = ( $ENV{LANGUAGE} || $ENV{LC_ALL} || $ENV{LC_MESSAGES} );
+        say STDERR __x(
+            "Warning: setting locale category LC_MESSAGES to {locale} failed -- is it installed on this system?\n\n",
+            locale => $locale );
     }
-    
+
     if ( not defined setlocale( LC_CTYPE, "" ) ) {
-        my $locale = ($ENV{LC_ALL} || $ENV{LC_CTYPE});
-        say STDERR __x( "Warning: setting locale category LC_CTYPE to {locale} failed -- is it installed on this system?\n\n",
-                       locale => $locale)
+        my $locale = ( $ENV{LC_ALL} || $ENV{LC_CTYPE} );
+        say STDERR __x(
+            "Warning: setting locale category LC_CTYPE to {locale} failed -- is it installed on this system?\n\n",
+            locale => $locale );
     }
 
     if ( $opt_version ) {
@@ -203,7 +206,8 @@ sub run {
 
     if ( defined $opt_json_translate ) {
         unless ( $opt_json or $opt_json_stream ) {
-            printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." ) . "\n";
+            printf STDERR __( "Warning: --json-translate has no effect without either --json or --json-stream." )
+              . "\n";
         }
         if ( $opt_json_translate ) {
             printf STDERR __( "Warning: deprecated --json-translate, use --no-raw instead." ) . "\n";
@@ -257,15 +261,16 @@ sub run {
 
     my @testing_suite;
     if ( @opt_test ) {
-        my %existing_tests = Zonemaster::Engine->all_methods;
+        my %existing_tests        = Zonemaster::Engine->all_methods;
         my @existing_test_modules = keys %existing_tests;
-        my @existing_test_cases = map { @{ $existing_tests{$_} } } @existing_test_modules;
+        my @existing_test_cases   = map { @{ $existing_tests{$_} } } @existing_test_modules;
 
         foreach my $t ( @opt_test ) {
             # There should be at most one slash character
             if ( $t =~ tr/\/// > 1 ) {
-                say STDERR __x( "Error: Invalid input '{cli_arg}' in --test. There must be at most one slash ('/') character.",
-                                cli_arg => $t);
+                say STDERR __x(
+                    "Error: Invalid input '{cli_arg}' in --test. There must be at most one slash ('/') character.",
+                    cli_arg => $t );
                 return $EXIT_USAGE_ERROR;
             }
 
@@ -273,43 +278,45 @@ sub run {
             $t = lc( $t );
 
             my ( $module, $method );
-            # Fully qualified module and test case (e.g. Example/example12), or just a test case (e.g. example12). Note the different capturing order.
-            if ( ( ($module, $method) = $t =~ m#^ ( [a-z]+ ) / ( [a-z]+[0-9]{2} ) $#ix )
-                or
-                 ( ($method, $module) = $t =~ m#^ ( ( [a-z]+ ) [0-9]{2} ) $#ix ) )
+# Fully qualified module and test case (e.g. Example/example12), or just a test case (e.g. example12). Note the different capturing order.
+            if (   ( ( $module, $method ) = $t =~ m#^ ( [a-z]+ ) / ( [a-z]+[0-9]{2} ) $#ix )
+                or ( ( $method, $module ) = $t =~ m#^ ( ( [a-z]+ ) [0-9]{2} ) $#ix ) )
             {
                 # Check that test module exists
-                if ( grep( /^$module$/,  map { lc($_) } @existing_test_modules ) ) {
+                if ( grep( /^$module$/, map { lc( $_ ) } @existing_test_modules ) ) {
                     # Check that test case exists
                     if ( grep( /^$method$/, @existing_test_cases ) ) {
                         push @testing_suite, "$module/$method";
                     }
                     else {
-                        say STDERR __x( "Error: Unrecognized test case '{testcase}' in --test. Use --list-tests for a list of valid choices.",
-                                        testcase => $method );
+                        say STDERR __x(
+"Error: Unrecognized test case '{testcase}' in --test. Use --list-tests for a list of valid choices.",
+                            testcase => $method
+                        );
                         return $EXIT_USAGE_ERROR;
                     }
                 }
                 else {
-                    say STDERR __x( "Error: Unrecognized test module '{module}' in --test. Use --list-tests for a list of valid choices.",
-                                    module => $module );
+                    say STDERR __x(
+"Error: Unrecognized test module '{module}' in --test. Use --list-tests for a list of valid choices.",
+                        module => $module
+                    );
                     return $EXIT_USAGE_ERROR;
                 }
-            }
+            } ## end if ( ( ( $module, $method...)))
             # Just a module name (e.g. Example) or something invalid.
             else {
                 $t =~ s{/$}{};
                 # Check that test module exists
-                if ( grep( /^$t$/,  map { lc($_) } @existing_test_modules ) ) {
+                if ( grep( /^$t$/, map { lc( $_ ) } @existing_test_modules ) ) {
                     push @testing_suite, $t;
                 }
                 else {
-                    say STDERR __x( "Error: Invalid input '{cli_arg}' in --test.",
-                                    cli_arg => $t);
+                    say STDERR __x( "Error: Invalid input '{cli_arg}' in --test.", cli_arg => $t );
                     return $EXIT_USAGE_ERROR;
                 }
             }
-        }
+        } ## end foreach my $t ( @opt_test )
 
         # Start with all profile-enabled test cases
         my @actual_test_cases = @{ Zonemaster::Engine::Profile->effective->get( 'test_cases' ) };
@@ -324,11 +331,12 @@ sub run {
         # Check if more test cases need to be included in the profile
         foreach my $t ( @testing_suite ) {
             # Either a module/method, or just a module
-            my ( $module, $method ) = split('/', $t);
+            my ( $module, $method ) = split( '/', $t );
             if ( $method ) {
                 # Test case in not already in the profile, we add it explicitly and notify the user
                 if ( not grep( /^$method$/, @actual_test_cases ) ) {
-                    say $fh_diag __x( "Notice: Engine does not have test case '{testcase}' enabled in the profile. Forcing...",
+                    say $fh_diag __x(
+                        "Notice: Engine does not have test case '{testcase}' enabled in the profile. Forcing...",
                         testcase => $method );
                     push @actual_test_cases, $method;
                 }
@@ -342,11 +350,11 @@ sub run {
                     push @actual_test_cases, @{ $existing_tests{$module} };
                 }
             }
-        }
+        } ## end foreach my $t ( @testing_suite)
 
         # Configure Engine to include all of the required test cases in the profile
         Zonemaster::Engine::Profile->effective->set( 'test_cases', [ uniq sort @actual_test_cases ] );
-    }
+    } ## end if ( @opt_test )
 
     # These two must come after any profile from command line has been loaded
     # to make any IPv4/IPv6 option override the profile setting.
@@ -391,7 +399,7 @@ sub run {
         module   => 12,
         testcase => 14
     );
-    my %header_names = ();
+    my %header_names    = ();
     my %remaining_space = ();
 
     # Callback defined here so it closes over the setup above.
@@ -427,29 +435,29 @@ sub run {
             else {
                 my $prefix = q{};
                 if ( $opt_time ) {
-                    $prefix .= sprintf "%*.2f ", ${field_width{seconds}}, $entry->timestamp;
+                    $prefix .= sprintf "%*.2f ", ${ field_width { seconds } }, $entry->timestamp;
                 }
 
                 if ( $opt_show_level ) {
                     $prefix .= $opt_raw ? $entry->level : translate_severity( $entry->level );
                     my $space_l10n =
-                        ${ field_width { level } } - length( decode_utf8( translate_severity( $entry_level ) ) ) + 1;
+                      ${ field_width { level } } - length( decode_utf8( translate_severity( $entry_level ) ) ) + 1;
                     $prefix .= ' ' x $space_l10n;
                 }
 
                 if ( $opt_show_module ) {
-                    $prefix .= sprintf "%-*s ", ${field_width{module}}, $entry->module;
+                    $prefix .= sprintf "%-*s ", ${ field_width { module } }, $entry->module;
                 }
 
                 if ( $opt_show_testcase ) {
-                    $prefix .= sprintf "%-*s ", ${field_width{testcase}}, $entry->testcase;
+                    $prefix .= sprintf "%-*s ", ${ field_width { testcase } }, $entry->testcase;
                 }
 
                 if ( $opt_raw ) {
                     $prefix .= $entry->tag;
 
                     my $message = $entry->argstr;
-                    my @lines = split /\n/, $message;
+                    my @lines   = split /\n/, $message;
 
                     printf "%s%s %s\n", $prefix, ' ', @lines ? shift @lines : '';
                     for my $line ( @lines ) {
@@ -457,8 +465,11 @@ sub run {
                     }
                 }
                 else {
-                    if ( $entry_level eq q{DEBUG3} and scalar( keys %{$entry->args} ) == 1 and defined $entry->args->{packet} ) {
-                        my $packet = $entry->args->{packet};
+                    if (    $entry_level eq q{DEBUG3}
+                        and scalar( keys %{ $entry->args } ) == 1
+                        and defined $entry->args->{packet} )
+                    {
+                        my $packet  = $entry->args->{packet};
                         my $padding = q{ } x length $prefix;
                         $entry->args->{packet} = q{};
                         printf "%s%s\n", $prefix, $translator->translate_tag( $entry );
@@ -470,10 +481,14 @@ sub run {
                         printf "%s%s\n", $prefix, $translator->translate_tag( $entry );
                     }
                 }
-            }
-        }
+            } ## end else [ if ( $opt_json and $opt_json_stream)]
+        } ## end if ( $numeric{ uc $entry_level...})
         if ( $opt_stop_level and $numeric{ uc $entry->level } >= $numeric{$opt_stop_level} ) {
-            die( Zonemaster::Engine::Exception::NormalExit->new( { message => "Saw message at level " . $entry->level } ) );
+            die(
+                Zonemaster::Engine::Exception::NormalExit->new(
+                    { message => "Saw message at level " . $entry->level }
+                )
+            );
         }
     };
 
@@ -486,7 +501,6 @@ sub run {
             push @held_messages, @_;
         }
     );
-
 
     if ( @argv > 1 ) {
         say STDERR __(
@@ -545,7 +559,7 @@ sub run {
 
         Zonemaster::Engine::Recursor->remove_fake_addresses( '.' );
         Zonemaster::Engine::Recursor->add_fake_addresses( '.', $hints_data );
-    }
+    } ## end if ( defined $opt_hints)
 
     # This can generate early log messages.
     if ( @opt_ns ) {
@@ -618,21 +632,21 @@ sub run {
         $header .= sprintf "%s\n", "=" x $field_width{message};
 
         print $header;
-    }
+    } ## end if ( not $opt_raw and ...)
 
     # Now we are ready to actually print messages, including those that are
     # currently in the hold queue.
-    while (my $entry = pop @held_messages) {
-        $message_printer->($entry);
+    while ( my $entry = pop @held_messages ) {
+        $message_printer->( $entry );
     }
-    Zonemaster::Engine->logger->callback($message_printer);
+    Zonemaster::Engine->logger->callback( $message_printer );
 
     # Actually run tests!
     eval {
         if ( @opt_test ) {
             foreach my $t ( @testing_suite ) {
                 # Either a module/method, or just a module
-                my ( $module, $method ) = split('/', $t);
+                my ( $module, $method ) = split( '/', $t );
                 if ( $method ) {
                     Zonemaster::Engine->test_method( $module, $method, $domain );
                 }
@@ -717,12 +731,13 @@ sub run {
 
     if ( $opt_nstimes ) {
         my $zone = Zonemaster::Engine->zone( $domain );
-        my $max = max map { length( "$_" ) } ( @{ $zone->ns }, q{Server} );
+        my $max  = max map { length( "$_" ) } ( @{ $zone->ns }, q{Server} );
 
         if ( $opt_json ) {
             my @times = ();
             foreach my $ns ( @{ $zone->ns } ) {
-                push @times, {
+                push @times,
+                  {
                     'ns'     => $ns->string,
                     'max'    => 1000 * $ns->max_time,
                     'min'    => 1000 * $ns->min_time,
@@ -730,13 +745,13 @@ sub run {
                     'stddev' => 1000 * $ns->stddev_time,
                     'median' => 1000 * $ns->median_time,
                     'total'  => 1000 * $ns->sum_time
-                };
+                  };
             }
             $json_output->{nstimes} = \@times;
         }
         else {
             print "\n";
-            printf "%${max}s %s\n", 'Server', '      Max      Min      Avg   Stddev   Median     Total';
+            printf "%${max}s %s\n", 'Server',   '      Max      Min      Avg   Stddev   Median     Total';
             printf "%${max}s %s\n", '=' x $max, ' ======== ======== ======== ======== ======== =========';
 
             foreach my $ns ( @{ $zone->ns } ) {
@@ -749,7 +764,7 @@ sub run {
                 printf "%9.2f\n",   1000 * $ns->sum_time;
             }
         }
-    }
+    } ## end if ( $opt_nstimes )
 
     if ( $opt_elapsed ) {
         my $last = Zonemaster::Engine->logger->entries->[-1];
@@ -767,7 +782,7 @@ sub run {
         $res = $JSON->decode( $res );
         foreach ( @$res ) {
             unless ( $opt_raw ) {
-                my %e = %$_;
+                my %e     = %$_;
                 my $entry = Zonemaster::Engine::Logger::Entry->new( \%e );
                 $_->{message} = $translator->translate_tag( $entry );
             }
@@ -788,7 +803,7 @@ sub run {
     }
 
     return $EXIT_SUCCESS;
-}
+} ## end sub run
 
 sub check_fake_delegation {
     my ( $domain, @ns ) = @_;
@@ -803,7 +818,7 @@ sub check_fake_delegation {
         ( my $errors, $name ) = normalize_name( decode( 'utf8', $name ) );
 
         if ( scalar @$errors > 0 ) {
-            my $error_message = "Invalid name in --ns argument:\n" ;
+            my $error_message = "Invalid name in --ns argument:\n";
             foreach my $err ( @$errors ) {
                 $error_message .= "\t" . $err->string . "\n";
             }
@@ -812,22 +827,25 @@ sub check_fake_delegation {
 
         if ( $ip ) {
             my $net_ip = Net::IP::XS->new( $ip );
-	    unless( validate_ipv4( $ip ) or validate_ipv6( $ip ) )
-	    {
-                die Net::IP::XS::Error() ? "Invalid IP address in --ns argument:\n\t". Net::IP::XS::Error() ."\n" : "Invalid IP address in --ns argument.\n";
+            unless ( validate_ipv4( $ip ) or validate_ipv6( $ip ) ) {
+                die Net::IP::XS::Error()
+                  ? "Invalid IP address in --ns argument:\n\t" . Net::IP::XS::Error() . "\n"
+                  : "Invalid IP address in --ns argument.\n";
             }
         }
-    }
+    } ## end foreach my $pair ( @ns )
 
     return;
-}
+} ## end sub check_fake_delegation
 
 sub check_fake_ds {
     my ( @ds ) = @_;
 
     foreach my $str ( @ds ) {
         unless ( $str =~ /$DS_RE/ ) {
-            say STDERR __( "--ds ds data must be in the form \"keytag,algorithm,type,digest\". E.g. space is not permitted anywhere in the string.");
+            say STDERR __(
+"--ds ds data must be in the form \"keytag,algorithm,type,digest\". E.g. space is not permitted anywhere in the string."
+            );
             exit( 1 );
         }
     }
@@ -846,7 +864,7 @@ sub add_fake_delegation {
         ( my $errors, $name ) = normalize_name( decode( 'utf8', $name ) );
 
         if ( $ip ) {
-            push @{ $data{ $name } }, $ip;
+            push @{ $data{$name} }, $ip;
         }
         else {
             push @ns_with_no_ip, $name;
@@ -854,14 +872,14 @@ sub add_fake_delegation {
     }
 
     foreach my $ns ( @ns_with_no_ip ) {
-        if ( not exists $data{ $ns } ) {
-            $data{ $ns } = undef;
+        if ( not exists $data{$ns} ) {
+            $data{$ns} = undef;
         }
     }
 
     return Zonemaster::Engine->add_fake_delegation( $domain => \%data );
 
-}
+} ## end sub add_fake_delegation
 
 sub add_fake_ds {
     my ( $domain, @ds ) = @_;
@@ -889,11 +907,11 @@ sub print_versions {
 my @spinner_strings = ( '  | ', '  / ', '  - ', '  \\ ' );
 
 sub print_spinner {
-    state $counter = 0;
-    state $last_spin = [0, 0];
+    state $counter   = 0;
+    state $last_spin = [ 0, 0 ];
 
-    my $time = [Time::HiRes::gettimeofday()];
-    if ( Time::HiRes::tv_interval($last_spin, $time) > 0.1 ) {
+    my $time = [ Time::HiRes::gettimeofday() ];
+    if ( Time::HiRes::tv_interval( $last_spin, $time ) > 0.1 ) {
         $last_spin = $time;
         printf "%s\r", $spinner_strings[ $counter++ % 4 ];
     }
@@ -920,7 +938,7 @@ sub print_test_list {
 sub do_dump_profile {
     my $json = JSON::XS->new->canonical->pretty;
 
-    print $json->encode( Zonemaster::Engine::Profile->effective->{ q{profile} } );
+    print $json->encode( Zonemaster::Engine::Profile->effective->{q{profile}} );
 
     return;
 }
@@ -948,13 +966,13 @@ sub translate_severity {
     else {
         return $severity;
     }
-}
+} ## end sub translate_severity
 
 sub _max {
     my ( $a, $b ) = @_;
     $a //= 0;
     $b //= 0;
-    return ( $a > $b ? $a : $b ) ;
+    return ( $a > $b ? $a : $b );
 }
 
 1;

--- a/lib/Zonemaster/CLI/TestCaseSet.pm
+++ b/lib/Zonemaster/CLI/TestCaseSet.pm
@@ -7,72 +7,149 @@ use Carp qw( croak );
 
 =head1 NAME
 
-    Zonemaster::CLI::TestCaseSet - A mutable set of test case names.
+    Zonemaster::CLI::TestCaseSet - Manage and modify Zonemaster test case selections
 
 =head1 SYNOPSIS
 
     use Zonemaster::CLI::TestCaseSet;
 
-    # Construct a working subset of test cases {alpha01, alpha02, alpha03,
-    # beta01} of test cases out of the full set {alpha01, alpha02, alpha03,
-    # beta01, beta02} distributed across the test modules {alpha, beta}.
-    my $working_set = Zonemaster::CLI::TestCaseSet->new(
-        \qw( alpha01 alpha02 alpha03 beta01 ),
-        {
-            alpha => \qw( alpha01 alpha02 alpha03 ),
-            beta  => \qw( beta01 beta02 ),
-        },
+    # Define the names of the available test modules and their test cases
+    my $schema = {
+        alpha => [qw( alpha01 alpha02 alpha03 )],
+        beta  => [qw( beta01 beta02 )],
+    };
+
+    # Construct an initial selection of test cases
+    my $selection = Zonemaster::CLI::TestCaseSet->new(
+        [qw( alpha01 alpha02 alpha03 beta01 )],
+        $schema,
     );
 
-    # Parse a modifier expression into a list of modifiers.
+    # Parse and apply a modifier expression
     my @modifiers = Zonemaster::CLI::TestCaseSet->parse_modifier_expr( '-alpha+alpha02' );
-
-    # Traverse the list of modifiers, chunked into (operator, term) pairs.
     while ( @modifiers ) {
-        my $op   = shift @modifiers;
-        my $term = shift @modifiers;
-
-        # Modify the working subset by applying each operator and term.
-        if ( !$working_set->apply_modifier( $op, $term ) ) {
-            die "Error: Unrecognized term '$term'.\n";
-        }
+        my ( $op, $term ) = splice @modifiers, 0, 2;
+        $selection->apply_modifier( $op, $term )
+          or die "Error: Unrecognized term '$term'.\n";
     }
 
-    # Make sure the working subset ends up in the expected state.
-    if ( join(' ', $working_set->to_list) ne 'alpha02 beta01' ) {
-        die;
-    }
+    # Output final test case selection
+    print join( ' ', $selection->to_list );    # alpha02 beta01
 
 =head1 DESCRIPTION
 
-A TestCaseSet primarily represents an immutable full set of test cases and a
-mutable subset thereof. The full set of test cases is distributed across the
-set of test modules.
+Zonemaster::CLI::TestCaseSet represents a mutable selection of test cases,
+together with an immutable schema defining available test modules and their
+associated test cases.
 
-=head2 TERM EXPANSION
+The schema is defined as a mapping of test module names to their associated test
+case names.
 
-Terms are expanded in one of three ways.
+The selection can be adjusted using modifier expressions.
+
+=head2 MODIFIER EXPRESSIONS
+
+A modifier expression describes a change to the current selection.
+Expressions combine terms using operators, e.g., C<'-alpha+alpha02'>.
+
+These operators are supported:
 
 =over 4
 
-=item The full set of test cases as provided to the TestCaseSet constructor for the current object.
+=item C<'+'> (union)
 
-Terms matching the string C<'all'>.
+Add test cases expanded from C<$term> to the current selection.
 
-=item The set of all test cases inside one test module.
+=item C<'-'> (difference)
 
-Terms matching the name of a test module.
+Remove test cases expanded C<$term> from the current selection.
 
-=item The singleton set of a single test cases
+=item C<''> (replace)
 
-Terms matching the name of a test case (e.g. "Case10") or the concatenation of a test module,
-a slash and a test cases belonging to that test module (e.g. "Case/Case10").
+Replace the entire current selection with the test cases expanded from C<$term>.
 
 =back
 
-Term names are matched case insensitively.
+Terms expand into sets of test cases in one of three ways:
 
-=head1 SUBROUTINES
+=over 4
+
+=item C<all>
+
+Expands to all available test cases defined by the schema.
+
+=item Test module name
+
+Expands to all test cases associated with the test module.
+
+=item Test case name
+
+Expands directly to the specified test case itself.
+Test cases may be specified plainly (e.g., C<Case10>) or fully qualified
+(module/testcase, e.g., C<Case/Case10>).
+
+=back
+
+Term matching is case-insensitive.
+
+=cut
+
+=head1 CONSTRUCTORS
+
+=head2 new( $selection, $schema )
+
+Construct a new TestCaseSet object.
+
+=over 4
+
+=item C<$selection> (arrayref)
+
+Initial selection of test case names.
+
+=item C<$schema> (hashref)
+
+A hash mapping test module names to arrays of their associated test case names.
+
+=back
+
+Dies if:
+- Any test case name in C<$schema> is repeated.
+- C<$selection> contains names not found in C<$schema>.
+
+=cut
+
+sub new {
+    my ( $class, $selection, $schema ) = @_;
+
+    my %cases = map { lc $_ => 1 } map { @{$_} } values %$schema;
+    for my $case ( @$selection ) {
+        if ( !exists $cases{ lc $case } ) {
+            croak "Unrecognized initial test case '$case'";
+        }
+    }
+
+    my $obj = {
+        _selection => { map { lc $_ => 1 } @$selection },
+        _terms     => _get_schema_terms( $schema ),
+    };
+
+    bless $obj, $class;
+
+    return $obj;
+}
+
+=head1 CLASS METHODS
+
+parse_modifier_expr( $modifier_expr )
+
+Parse a string containing a modifier expression and returns a list of
+alternating operators and terms.
+
+The returned list always starts with an operator.
+
+For example, parsing C<'-alpha+beta02'> returns:
+
+    ('-', 'alpha', '+', 'beta02')
 
 =cut
 
@@ -90,94 +167,46 @@ sub parse_modifier_expr {
     return @modifiers;
 }
 
-=head1 CONSTRUCTORS
-
-=head2 new()
-
-In the full set of test cases, methods names must not share the same name as
-other test cases or test modules.
-
-=cut
-
-sub new {
-    my ( $class, $initial_methods, %all_methods ) = @_;
-
-    my %flattened_methods = map { $_ => 1 } map { @{$_} } values %all_methods;
-    for my $method ( @$initial_methods ) {
-        if ( !exists $flattened_methods{$method} ) {
-            croak "Unrecognized initial method '$method'";
-        }
-    }
-
-    my $obj = {
-        _cur_methods      => { map { $_ => 1 } @$initial_methods },
-        _all_term_methods => _get_all_term_methods( \%all_methods ),
-    };
-
-    bless $obj, $class;
-
-    return $obj;
-}
-
 =head1 INSTANCE METHODS
 
-=head2 apply_modifier()
+=head2 apply_modifier( $operator, $term )
 
-Update the working subset.
+Update the selection using the given operator and term.
 
-The given operator is applied to two operands and the result is assigned to the
-working subset. The left hand side operand is the current value of the working
-subset. The right hand side operand is calculated by L<expanding|/"TERM
-EXPANSION"> the given term to a subset of test cases.
+Returns true if successful, or false if the term could not be expanded based on
+the schema.
 
-Three operators are supported.
+Dies if the operator is invalid.
 
-=over 4
+=head3 Example:
 
-=item C<'+'>
-
-Returns the union of the left and right hand side operands
-
-=item C<'-'>
-
-Returns the set difference of the left and right hand side operands
-
-=item C<''>
-
-Ignores the left hand side operand and returns the right hand side operand.
-
-=back
-
-Returns true if the operation is successful.
-
-Returns false if the term could not be expanded.
-
-Dies if the operator is not recognized.
+    $selection->apply_modifier('+', 'beta') 
+        or die "Unrecognized term";
 
 =cut
 
 sub apply_modifier {
     my ( $self, $op, $term ) = @_;
 
-    my $methods_ref = $self->{_all_term_methods}{ lc $term };
+    my $cases_ref = $self->{_terms}{ lc $term };
 
-    if ( !defined $methods_ref ) {
+    if ( !defined $cases_ref ) {
         return 0;
     }
 
     if ( $op eq '' ) {
-        $self->{_cur_methods} = {};
+        $self->{_selection} = {};
         $op = '+';
     }
 
     if ( $op eq '-' ) {
-        for my $method ( @$methods_ref ) {
-            delete $self->{_cur_methods}{$method};
+        for my $case ( @$cases_ref ) {
+            delete $self->{_selection}{$case};
         }
     }
     elsif ( $op eq '+' ) {
-        for my $method ( @$methods_ref ) {
-            $self->{_cur_methods}{$method} = 1;
+        for my $case ( @$cases_ref ) {
+            $self->{_selection}{$case} = 1;
         }
     }
     else {
@@ -187,47 +216,53 @@ sub apply_modifier {
     return 1;
 } ## end sub apply_modifier
 
+=head2 to_list
+
+Return a lowercase list of the currently selected test case names.
+
+=cut
+
 sub to_list {
     my ( $self ) = @_;
 
-    return sort keys %{ $self->{_cur_methods} };
+    return sort keys %{ $self->{_selection} };
 }
 
-sub _get_all_term_methods {
-    my ( $all_methods ) = @_;
+sub _get_schema_terms {
+    my ( $schema ) = @_;
 
     my $terms = {};
     $terms->{all} = [];
 
-    for my $module ( keys %$all_methods ) {
+    for my $module ( keys %$schema ) {
         if ( lc $module eq 'all' ) {
-            croak "module name must not be 'all'";
+            croak "test module name must not be 'all'";
         }
         if ( $module =~ qr{/} ) {
-            croak "module name contains forbidden character '/': '$module'";
+            croak "test module name contains forbidden character '/': '$module'";
         }
         if ( exists $terms->{ lc $module } ) {
-            croak "found module with same name as another method or module: '$module'";
+            croak "found test module with same name as another test case or test module: '$module'";
         }
         $terms->{ lc $module } = [];
-        for my $method ( @{ $all_methods->{$module} } ) {
-            if ( lc $method eq 'all' ) {
-                croak "method name must not be 'all'";
+        for my $case ( @{ $schema->{$module} } ) {
+            if ( lc $case eq 'all' ) {
+                croak "test case name must not be 'all'";
             }
-            if ( $method =~ qr{/} ) {
-                croak "method name contains forbidden character '/': '$method'";
+            if ( $case =~ qr{/} ) {
+                croak "test case name contains forbidden character '/': '$case'";
             }
-            if ( exists $terms->{ lc $method } ) {
-                croak "found method with same name as another method or module: '$method'";
+            if ( exists $terms->{ lc $case } ) {
+                croak "found test case with same name as another test case or test module: '$case'";
             }
-            $terms->{ lc $method } = [$method];
-            $terms->{ lc "$module/$method" } = [$method];
-            push @{ $terms->{ lc $module } }, $method;
-            push @{ $terms->{all} },          $method;
+            $terms->{ lc $case } = [$case];
+            $terms->{ lc "$module/$case" } = [$case];
+            push @{ $terms->{ lc $module } }, $case;
+            push @{ $terms->{all} },          $case;
         }
-    } ## end for my $module ( keys %$all_methods)
+    } ## end for my $module ( keys %$schema)
 
     return $terms;
-} ## end sub _get_all_term_methods
+} ## end sub _get_schema_terms
 
 1;

--- a/lib/Zonemaster/CLI/TestCaseSet.pm
+++ b/lib/Zonemaster/CLI/TestCaseSet.pm
@@ -1,0 +1,233 @@
+package Zonemaster::CLI::TestCaseSet;
+use 5.014;
+use warnings;
+use utf8;
+
+use Carp qw( croak );
+
+=head1 NAME
+
+    Zonemaster::CLI::TestCaseSet - A mutable set of test methods names.
+
+=head1 SYNOPSIS
+
+    use Zonemaster::CLI::TestCaseSet;
+
+    # Construct a working subset of test methods {alpha01, alpha02, alpha03,
+    # beta01} of test methods out of the full set {alpha01, alpha02, alpha03,
+    # beta01, beta02} distributed across the test modules {alpha, beta}.
+    my $working_set = Zonemaster::CLI::TestCaseSet->new(
+        \qw( alpha01 alpha02 alpha03 beta01 ),
+        {
+            alpha => \qw( alpha01 alpha02 alpha03 ),
+            beta  => \qw( beta01 beta02 ),
+        },
+    );
+
+    # Parse a modifier expression into a list of modifiers.
+    my @modifiers = Zonemaster::CLI::TestCaseSet->parse_modifier_expr( '-alpha+alpha02' );
+
+    # Traverse the list of modifiers, chunked into (operator, term) pairs.
+    while ( @modifiers ) {
+        my $op   = shift @modifiers;
+        my $term = shift @modifiers;
+
+        # Modify the working subset by applying each operator and term.
+        if ( !$working_set->apply_modifier( $op, $term ) ) {
+            die "Error: Unrecognized term '$term'.\n";
+        }
+    }
+
+    # Make sure the working subset ends up in the expected state.
+    if ( join(' ', $working_set->to_list) ne 'alpha02 beta01' ) {
+        die;
+    }
+
+=head1 DESCRIPTION
+
+A TestCaseSet primarily represents an immutable full set of test methods and a
+mutable subset thereof. The full set of test methods is distributed across the
+set of test modules.
+
+=head2 TERM EXPANSION
+
+Terms are expanded in one of three ways.
+
+=over 4
+
+=item The full set of all test methods.
+
+The term matching the string C<'all'>.
+
+=item The set of all test methods inside one test module.
+
+Terms matching the name of a test module.
+
+=item The singleton set of a single test methods
+
+Terms matching the name of a test methods or the concatenation of a test module,
+a slash and a test methods belonging to that test module.
+
+=back
+
+Term names are matched case insensitively.
+
+=head1 SUBROUTINES
+
+=cut
+
+sub parse_modifier_expr {
+    my ( $class, $modifier_expr ) = @_;
+
+    my @modifiers;
+    for my $op_and_term ( split /(?=[+-])/, $modifier_expr ) {
+        $op_and_term =~ /([+-]?)(.*)/;
+        my ( $op, $term ) = ( $1, $2 );
+
+        push @modifiers, ( $op, $term );
+    }
+
+    return @modifiers;
+}
+
+=head1 CONSTRUCTORS
+
+=head2 new()
+
+In the full set of test methods, methods names must not share the same name as
+other test methods or test modules.
+
+=cut
+
+sub new {
+    my ( $class, $initial_methods, %all_methods ) = @_;
+
+    my %flattened_methods = map { $_ => 1 } map { @{$_} } values %all_methods;
+    for my $method ( @$initial_methods ) {
+        if ( !exists $flattened_methods{$method} ) {
+            croak "Unrecognized initial method '$method'";
+        }
+    }
+
+    my $obj = {
+        _cur_methods      => { map { $_ => 1 } @$initial_methods },
+        _all_term_methods => _get_all_term_methods( \%all_methods ),
+    };
+
+    bless $obj, $class;
+
+    return $obj;
+}
+
+=head1 INSTANCE METHODS
+
+=head2 apply_modifier()
+
+Update the working subset.
+
+The given operator is applied to two operands and the result is assigned to the
+working subset. The left hand side operand is the current value of the working
+subset. The right hand side operand is calculated by L<expanding|/"TERM
+EXPANSION"> the given term to a subset of test methods.
+
+Three operators are supported.
+
+=over 4
+
+=item C<'+'>
+
+Returns the union of the left and right hand side operands
+
+=item C<'-'>
+
+Returns the set difference of the left and right hand side operands
+
+=item C<''>
+
+Ignores the left hand side operand and returns the right hand side operand.
+
+=back
+
+Returns true if the operation is successful.
+
+Returns false if the term could not be expanded.
+
+Dies if the operator is not recognized.
+
+=cut
+
+sub apply_modifier {
+    my ( $self, $op, $term ) = @_;
+
+    my $methods_ref = $self->{_all_term_methods}{ lc $term };
+
+    if ( !defined $methods_ref ) {
+        return 0;
+    }
+
+    if ( $op eq '' ) {
+        $self->{_cur_methods} = {};
+        $op = '+';
+    }
+
+    if ( $op eq '-' ) {
+        for my $method ( @$methods_ref ) {
+            delete $self->{_cur_methods}{$method};
+        }
+    }
+    elsif ( $op eq '+' ) {
+        for my $method ( @$methods_ref ) {
+            $self->{_cur_methods}{$method} = 1;
+        }
+    }
+    else {
+        croak "Unrecognized operator '$op'";
+    }
+
+    return 1;
+} ## end sub apply_modifier
+
+sub to_list {
+    my ( $self ) = @_;
+
+    return sort keys %{ $self->{_cur_methods} };
+}
+
+sub _get_all_term_methods {
+    my ( $all_methods ) = @_;
+
+    my $terms = {};
+    $terms->{all} = [];
+
+    for my $module ( keys %$all_methods ) {
+        if ( lc $module eq 'all' ) {
+            croak "module name must not be 'all'";
+        }
+        if ( $module =~ qr{/} ) {
+            croak "module name contains forbidden character '/': '$module'";
+        }
+        if ( exists $terms->{ lc $module } ) {
+            croak "found module with same name as another method or module: '$module'";
+        }
+        $terms->{ lc $module } = [];
+        for my $method ( @{ $all_methods->{$module} } ) {
+            if ( lc $method eq 'all' ) {
+                croak "method name must not be 'all'";
+            }
+            if ( $method =~ qr{/} ) {
+                croak "method name contains forbidden character '/': '$method'";
+            }
+            if ( exists $terms->{ lc $method } ) {
+                croak "found method with same name as another method or module: '$method'";
+            }
+            $terms->{ lc $method } = [$method];
+            $terms->{ lc "$module/$method" } = [$method];
+            push @{ $terms->{ lc $module } }, $method;
+            push @{ $terms->{all} },          $method;
+        }
+    } ## end for my $module ( keys %$all_methods)
+
+    return $terms;
+} ## end sub _get_all_term_methods
+
+1;

--- a/lib/Zonemaster/CLI/TestCaseSet.pm
+++ b/lib/Zonemaster/CLI/TestCaseSet.pm
@@ -65,8 +65,8 @@ Terms matching the name of a test module.
 
 =item The singleton set of a single test cases
 
-Terms matching the name of a test case or the concatenation of a test module,
-a slash and a test cases belonging to that test module.
+Terms matching the name of a test case (e.g. "Case10") or the concatenation of a test module,
+a slash and a test cases belonging to that test module (e.g. "Case/Case10").
 
 =back
 

--- a/lib/Zonemaster/CLI/TestCaseSet.pm
+++ b/lib/Zonemaster/CLI/TestCaseSet.pm
@@ -7,14 +7,14 @@ use Carp qw( croak );
 
 =head1 NAME
 
-    Zonemaster::CLI::TestCaseSet - A mutable set of test methods names.
+    Zonemaster::CLI::TestCaseSet - A mutable set of test case names.
 
 =head1 SYNOPSIS
 
     use Zonemaster::CLI::TestCaseSet;
 
-    # Construct a working subset of test methods {alpha01, alpha02, alpha03,
-    # beta01} of test methods out of the full set {alpha01, alpha02, alpha03,
+    # Construct a working subset of test cases {alpha01, alpha02, alpha03,
+    # beta01} of test cases out of the full set {alpha01, alpha02, alpha03,
     # beta01, beta02} distributed across the test modules {alpha, beta}.
     my $working_set = Zonemaster::CLI::TestCaseSet->new(
         \qw( alpha01 alpha02 alpha03 beta01 ),
@@ -45,8 +45,8 @@ use Carp qw( croak );
 
 =head1 DESCRIPTION
 
-A TestCaseSet primarily represents an immutable full set of test methods and a
-mutable subset thereof. The full set of test methods is distributed across the
+A TestCaseSet primarily represents an immutable full set of test cases and a
+mutable subset thereof. The full set of test cases is distributed across the
 set of test modules.
 
 =head2 TERM EXPANSION
@@ -55,18 +55,18 @@ Terms are expanded in one of three ways.
 
 =over 4
 
-=item The full set of all test methods.
+=item The full set of test cases.
 
-The term matching the string C<'all'>.
+Terms matching the string C<'all'>.
 
-=item The set of all test methods inside one test module.
+=item The set of all test cases inside one test module.
 
 Terms matching the name of a test module.
 
-=item The singleton set of a single test methods
+=item The singleton set of a single test cases
 
-Terms matching the name of a test methods or the concatenation of a test module,
-a slash and a test methods belonging to that test module.
+Terms matching the name of a test case or the concatenation of a test module,
+a slash and a test cases belonging to that test module.
 
 =back
 
@@ -94,8 +94,8 @@ sub parse_modifier_expr {
 
 =head2 new()
 
-In the full set of test methods, methods names must not share the same name as
-other test methods or test modules.
+In the full set of test cases, methods names must not share the same name as
+other test cases or test modules.
 
 =cut
 
@@ -128,7 +128,7 @@ Update the working subset.
 The given operator is applied to two operands and the result is assigned to the
 working subset. The left hand side operand is the current value of the working
 subset. The right hand side operand is calculated by L<expanding|/"TERM
-EXPANSION"> the given term to a subset of test methods.
+EXPANSION"> the given term to a subset of test cases.
 
 Three operators are supported.
 

--- a/lib/Zonemaster/CLI/TestCaseSet.pm
+++ b/lib/Zonemaster/CLI/TestCaseSet.pm
@@ -55,7 +55,7 @@ Terms are expanded in one of three ways.
 
 =over 4
 
-=item The full set of test cases.
+=item The full set of test cases as provided to the TestCaseSet constructor for the current object.
 
 Terms matching the string C<'all'>.
 

--- a/lib/Zonemaster/CLI/TestCaseSet.pm
+++ b/lib/Zonemaster/CLI/TestCaseSet.pm
@@ -58,15 +58,18 @@ These operators are supported:
 
 =item C<'+'> (union)
 
-Add test cases expanded from C<$term> to the current selection.
+Add test cases to the current selection.
+The set of test cases to add is the expansion of C<$term>.
 
 =item C<'-'> (difference)
 
-Remove test cases expanded C<$term> from the current selection.
+Remove test cases from the current selection.
+The set of test cases to remove is the expansion of C<$term>.
 
 =item C<''> (replace)
 
-Replace the entire current selection with the test cases expanded from C<$term>.
+Replace the current selection.
+The new selection is the set of test cases expanded from C<$term>.
 
 =back
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -125,7 +125,7 @@ An empty EXPR (C<--test=>) leaves C<test_cases> unchanged.
 Multiple C<--test> options may be provided; they are applied sequentially.
 When used with C<--profile>, that option is applied first.
 
-Use C<--list-tests> to list all available test cases and test modules.
+Use C<--list-tests> to list all available test cases and test modules in the default profile.
 
 Examples:
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -118,14 +118,15 @@ For details, see C<man zonemaster-cli>.
 =begin :man
 
 An EXPR starting with a term (e.g., C<all>, C<nameserver01>) completely replaces
-the current value of C<test_cases>.
-An EXPR starting with C<+> or C<-> modifies the existing C<test_cases>.
-An empty EXPR (C<--test=>) leaves C<test_cases> unchanged.
+the selection (i.e., the value of the C<test_cases> profile property).
+An EXPR starting with an operator applies a delta to the selection.
+An empty EXPR (C<--test=>) leaves the selection unchanged (formally, it is
+updated by applying the identity transformation).
 
 Multiple C<--test> options may be provided; they are applied sequentially.
 When used with C<--profile>, that option is applied first.
 
-Use C<--list-tests> to list all available test cases and test modules in the default profile.
+Use C<--list-tests> to list all test cases and test modules in the default profile.
 
 Examples:
 
@@ -133,7 +134,7 @@ Examples:
 
 =item --test=B<all>
 
-selects all available test cases.
+selects all test cases in the default profile.
 
 =item --test=B<nameserver>
 
@@ -154,15 +155,15 @@ Nameserver03.
 
 =item --test=B<-dnssec>
 
-removes all DNSSEC test cases.
+removes all DNSSEC test cases from the selection.
 
 =item --test=B<+syntax01+syntax02>
 
-adds Syntax01 and Syntax02 test cases.
+adds the Syntax01 and Syntax02 test cases to the selection.
 
 =item --test=
 
-leaves the existing C<test_cases> unmodified.
+leaves the selection unchanged.
 
 =back
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -120,7 +120,7 @@ For details, see C<man zonemaster-cli>.
 An EXPR starting with a term (e.g., C<all>, C<nameserver01>) I<replaces>
 the current selection.
 An EXPR starting with an operator (C<+> or C<->) I<modifies> the current selection.
-An empty EXPR (C<--test=>) keeps the current selection unchanged (i.e., it is a no-op).
+An empty EXPR (C<--test=>) does not modify the selection (i.e., it is a no-op).
 
 Multiple C<--test> options may be specified; they are applied in the order they are given.
 When used together with the C<--profile>, the profile option is applied first.

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -123,7 +123,7 @@ An EXPR starting with an operator (C<+> or C<->) I<modifies> the current selecti
 An empty EXPR (C<--test=>) keeps the current selection unchanged (i.e., it is a no-op).
 
 Multiple C<--test> options may be specified; they are applied in the order they are given.
-When used together with the C<--profile>, that option is applied first.
+When used together with the C<--profile>, the profile option is applied first.
 
 Use C<--list-tests> to list all test cases and test modules in the default profile.
 
@@ -133,11 +133,11 @@ Examples:
 
 =item --test=B<all>
 
-selects all test cases in the default profile.
+selects all test cases in the default profile, i.e. overrides any custom profile.
 
 =item --test=B<nameserver>
 
-selects all test cases in the Nameserver test module.
+selects all test cases in the Nameserver test module in the default profile.
 
 =item --test=B<nameserver01>
 
@@ -162,7 +162,7 @@ adds the Syntax01 and Syntax02 test cases to the selection.
 
 =item --test=
 
-leaves the selection unchanged.
+empty value is valid, but does not change the selection of test cases
 Specifying C<--test=> without an argument is a no-op.
 Having this possibility may come in handy when invoking zonemaster-cli from scripts.
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -110,21 +110,20 @@ Print the effective profile used in JSON format, then exit.
 
 =item B<--test>=EXPR
 
-Select test cases to run (sets the C<test_cases> profile property).
-EXPR is composed of terms (individual test cases, test modules, or C<all>) and
-operators (C<+> to add, C<-> to remove).
+Specify which test cases to run by setting the C<test_cases> property in the profile.
+The EXPR is a flexible expression consisting of terms (individual test cases, test
+modules, or all) and operators (C<+> to add, C<-> to remove).
 For details, see C<man zonemaster-cli>.
 
 =begin :man
 
-An EXPR starting with a term (e.g., C<all>, C<nameserver01>) completely replaces
-the selection (i.e., the value of the C<test_cases> profile property).
-An EXPR starting with an operator applies a delta to the selection.
-An empty EXPR (C<--test=>) leaves the selection unchanged (formally, it is
-updated by applying the identity transformation).
+An EXPR starting with a term (e.g., C<all>, C<nameserver01>) I<replaces>
+the current selection.
+An EXPR starting with an operator (C<+> or C<->) I<modifies> the current selection.
+An empty EXPR (C<--test=>) keeps the current selection unchanged (i.e., it is a no-op).
 
-Multiple C<--test> options may be provided; they are applied sequentially.
-When used with C<--profile>, that option is applied first.
+Multiple C<--test> options may be specified; they are applied in the order they are given.
+When used together with the C<--profile>, that option is applied first.
 
 Use C<--list-tests> to list all test cases and test modules in the default profile.
 
@@ -164,6 +163,8 @@ adds the Syntax01 and Syntax02 test cases to the selection.
 =item --test=
 
 leaves the selection unchanged.
+Specifying C<--test=> without an argument is a no-op.
+Having this possibility may come in handy when invoking zonemaster-cli from scripts.
 
 =back
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -9,37 +9,34 @@ use autodie;
 
 sub read_conf_file {
     # Returns list of command line parameters. List can be empty.
-    my ($conf_file) = @_;
+    my ( $conf_file ) = @_;
     my @lines;
     open my $fh, '<', $conf_file;
-    while (<$fh>) {
+    while ( <$fh> ) {
         chomp;
         next if /^\s*$/;
         next if /^\s*#/;
         push @lines, $_;
-    };
+    }
     return @lines;
 }
 
 # Load default arguments from file in home directory, if any
 # This must be loaded before any global file to make the local
 # file take precedence
-my $home_dir  = ((getpwuid($<))[7]) || $ENV{HOME};
-my $home_conf_file = File::Spec->catfile($home_dir, '.zonemaster', 'cli.args');
+my $home_dir       = ( ( getpwuid( $< ) )[7] ) || $ENV{HOME};
+my $home_conf_file = File::Spec->catfile( $home_dir, '.zonemaster', 'cli.args' );
 
-if (-r $home_conf_file) {
-    my @lines = read_conf_file ($home_conf_file);
+if ( -r $home_conf_file ) {
+    my @lines = read_conf_file( $home_conf_file );
     unshift @ARGV, @lines;
 }
 
 # Load default arguments from global file, if any
-my @global_conf = (
-    '/etc/zonemaster/cli.args',
-    '/usr/local/etc/zonemaster/cli.args'
-    ); # Order is significant.
+my @global_conf = ( '/etc/zonemaster/cli.args', '/usr/local/etc/zonemaster/cli.args' );    # Order is significant.
 my $global_conf_file;
 
-for my $p (@global_conf) {
+for my $p ( @global_conf ) {
     if ( -e $p and -r $p ) {
         $global_conf_file = $p;
         last;
@@ -47,7 +44,7 @@ for my $p (@global_conf) {
 }
 
 if ( defined $global_conf_file ) {
-    my @lines = read_conf_file ($global_conf_file);
+    my @lines = read_conf_file( $global_conf_file );
     unshift @ARGV, @lines;
 
 }
@@ -111,17 +108,65 @@ Print the effective profile used in JSON format, then exit.
 
 =over 4
 
-=item B<--test>=TESTCASE, B<--test>=TESTMODULE
+=item B<--test>=EXPR
 
-Limit the testing suite to run only the specified tests.
-Can be specified multiple times.
-(default: all test cases)
+Select test cases to run (sets the C<test_cases> profile property).
+EXPR is composed of terms (individual test cases, test modules, or C<all>) and
+operators (C<+> to add, C<-> to remove).
+For details, see C<man zonemaster-cli>.
 
-=for :man This can be the name of a testing module, in which case all test cases from
-that module will be run, or the name of a module followed by a slash and the
-name of a test case (test case identifier) in that module, or the name of the
-test case.
-This option is case-insensitive.
+=begin :man
+
+An EXPR starting with a term (e.g., C<all>, C<nameserver01>) completely replaces
+the current value of C<test_cases>.
+An EXPR starting with C<+> or C<-> modifies the existing C<test_cases>.
+An empty EXPR (C<--test=>) leaves C<test_cases> unchanged.
+
+Multiple C<--test> options may be provided; they are applied sequentially.
+When used with C<--profile>, that option is applied first.
+
+Use C<--list-tests> to list all available test cases and test modules.
+
+Examples:
+
+=over 4
+
+=item --test=B<all>
+
+selects all available test cases.
+
+=item --test=B<nameserver>
+
+selects all test cases in the Nameserver test module.
+
+=item --test=B<nameserver01>
+
+selects only the Nameserver01 test case.
+
+=item --test=B<dnssec-dnssec05>
+
+selects all DNSSEC test cases except DNSSEC05.
+
+=item --test=B<all-nameserver+nameserver03>
+
+selects all test cases, excludes the Nameserver test cases, and adds back
+Nameserver03.
+
+=item --test=B<-dnssec>
+
+removes all DNSSEC test cases.
+
+=item --test=B<+syntax01+syntax02>
+
+adds Syntax01 and Syntax02 test cases.
+
+=item --test=
+
+leaves the existing C<test_cases> unmodified.
+
+=back
+
+=end :man
 
 =item B<--level>=LEVEL
 

--- a/t/test_case_set.t
+++ b/t/test_case_set.t
@@ -1,0 +1,268 @@
+#!perl
+use 5.14.2;
+use utf8;
+use warnings;
+use Test::More;
+
+use Log::Any::Test;
+use Log::Any qw( $log );
+use Test::Differences;
+use Test::Exception;
+use Zonemaster::Engine;
+use Zonemaster::Engine::Profile;
+
+use Zonemaster::CLI::TestCaseSet;
+
+require Test::NoWarnings;
+
+lives_ok {    # Make sure we get to print log messages in case of errors.
+    subtest 'parse_modifier_expr' => sub {
+        my @cases = (
+            {
+                name     => 'empty',
+                expr     => '',
+                expected => [],
+            },
+            {
+                name     => 'absolute term',
+                expr     => 'term',
+                expected => [ '', 'term' ],
+            },
+            {
+                name     => 'absolute additive',
+                expr     => 'term',
+                expected => [ '', 'term' ],
+            },
+            {
+                name     => 'absolute subtractive',
+                expr     => 'term',
+                expected => [ '', 'term' ],
+            },
+            {
+                name     => 'absolute multiple modifiers',
+                expr     => 'term1+term2',
+                expected => [ '', 'term1', '+', 'term2' ],
+            },
+            {
+                name     => 'relative multiple modifiers',
+                expr     => '-term1+term2',
+                expected => [ '-', 'term1', '+', 'term2' ],
+            },
+        );
+        for my $case ( @cases ) {
+            subtest $case->{name} => sub {
+                my @actual = Zonemaster::CLI::TestCaseSet->parse_modifier_expr( $case->{expr} );
+                eq_or_diff \@actual, $case->{expected};
+            };
+        }
+    };
+
+    subtest 'new' => sub {
+        my @cases = (
+            {
+                name               => 'empty',
+                all_methods        => {},
+                initial_test_cases => [],
+                expect_ok          => {
+                    terms   => ['all'],
+                    methods => [],
+                },
+            },
+            {
+                name               => 'multiple test modules and test cases',
+                all_methods        => { 'alpha' => [ 'bravo', 'charlie' ], 'delta' => ['echo'] },
+                initial_test_cases => [ 'bravo', 'echo' ],
+                expect_ok          => {
+                    terms => [
+                        'all',   'alpha',   'alpha/bravo', 'alpha/charlie',
+                        'bravo', 'charlie', 'delta',       'delta/echo',
+                        'echo'
+                    ],
+                    methods => [ 'bravo', 'echo' ],
+                },
+            },
+            {
+                name               => 'illegal test module name 1',
+                all_methods        => { 'all' => [] },
+                initial_test_cases => [],
+                expect_err         => qr/must not be 'all'/i,
+            },
+            {
+                name               => 'illegal test module name 2',
+                all_methods        => { 'alpha/bravo' => [] },
+                initial_test_cases => [],
+                expect_err         => qr{contains forbidden character '/'}i,
+            },
+            {
+                name               => 'illegal test case name 1',
+                all_methods        => { 'alpha' => ['all'] },
+                initial_test_cases => [],
+                expect_err         => qr/must not be 'all'/i,
+            },
+            {
+                name               => 'illegal test case name 2',
+                all_methods        => { 'alpha' => ['bravo/charlie'] },
+                initial_test_cases => [],
+                expect_err         => qr{contains forbidden character '/'}i,
+            },
+            {
+                name               => 'duplicate term 1',
+                all_methods        => { 'alpha' => ['alpha'] },
+                initial_test_cases => [],
+                expect_err         => qr/same name/i,
+            },
+            {
+                name               => 'duplicate term 2',
+                all_methods        => { 'alpha' => [], 'bravo' => ['alpha'] },
+                initial_test_cases => [],
+                expect_err         => qr/same name/i,
+            },
+            {
+                name               => 'duplicate term 3',
+                all_methods        => { 'alpha' => [ 'bravo', 'bravo' ] },
+                initial_test_cases => [],
+                expect_err         => qr/same name/i,
+            },
+            {
+                name               => 'duplicate term 4',
+                all_methods        => { 'alpha' => ['bravo'], 'charlie' => ['bravo'] },
+                initial_test_cases => [],
+                expect_err         => qr/same name/i,
+            },
+            {
+                name               => 'unrecognized test case 1',
+                all_methods        => { 'alpha' => [] },
+                initial_test_cases => ['all'],
+                expect_err         => qr/unrecognized/i,
+            },
+            {
+                name               => 'unrecognized test case 2',
+                all_methods        => { 'alpha' => [] },
+                initial_test_cases => ['alpha'],
+                expect_err         => qr/unrecognized/i,
+            },
+        );
+        for my $case ( @cases ) {
+            subtest $case->{name} => sub {
+                my $test_cases;
+                local $@;
+                eval {
+                    $test_cases = Zonemaster::CLI::TestCaseSet->new(    #
+                        $case->{initial_test_cases},
+                        %{ $case->{all_methods} },
+                    );
+                };
+
+                my $err = $@;
+                my $actual;
+                if ( !$err ) {
+                    $actual = {
+                        terms   => [ sort keys %{ $test_cases->{_all_term_methods} } ],
+                        methods => [ $test_cases->to_list ],
+                    };
+                }
+
+                if ( defined $case->{expect_err} ) {
+                    like $err, $case->{expect_err}, "error";
+                } else {
+                    is $err, "", "no error";
+                }
+                if ( defined $case->{expect_ok} ) {
+                    eq_or_diff $actual, $case->{expect_ok}, "result";
+                } else {
+                    eq_or_diff $actual, undef, "no result";
+                }
+            }; ## end sub
+        } ## end for my $case ( @cases )
+    }; ## end 'new' => sub
+
+    subtest 'apply_modifier' => sub {
+        my @cases = (
+            {
+                name               => 'empty',
+                all_methods        => {},
+                initial_test_cases => [],
+                modifiers          => [],
+                expected           => [],
+            },
+            {
+                name               => 'no modifiers',
+                all_methods        => { basic => [ 'basic01', 'basic02' ] },
+                initial_test_cases => [ 'basic01' ],
+                modifiers          => [],
+                expected           => [ 'basic01' ],
+            },
+            {
+                name               => 'add a new case',
+                all_methods        => { basic => [ 'basic01', 'basic02' ] },
+                initial_test_cases => [ 'basic01' ],
+                modifiers          => [ '+', 'basic02' ],
+                expected           => [ 'basic01', 'basic02' ],
+            },
+            {
+                name               => 'add the same case',
+                all_methods        => { basic => [ 'basic01', 'basic02' ] },
+                initial_test_cases => [ 'basic01' ],
+                modifiers          => [ '+', 'basic01' ],
+                expected           => [ 'basic01' ],
+            },
+            {
+                name               => 'replace',
+                all_methods        => { basic => [ 'basic01', 'basic02' ] },
+                initial_test_cases => [ 'basic01' ],
+                modifiers          => [ '', 'basic02' ],
+                expected           => [ 'basic02' ],
+            },
+            {
+                name               => 'module expansion',
+                all_methods        => { basic => [ 'basic01' ], extra => ['extra01', 'extra02'] },
+                initial_test_cases => [ 'basic01' ],
+                modifiers          => [ '', 'extra' ],
+                expected           => [ 'extra01', 'extra02' ],
+            },
+            {
+                name               => 'all',
+                all_methods        => { basic => [ 'basic01' ], extra => ['extra01', 'extra02'] },
+                initial_test_cases => [ 'basic01' ],
+                modifiers          => [ '', 'all' ],
+                expected           => [ 'basic01', 'extra01', 'extra02' ],
+            },
+            {
+                name               => 'multiple modifiers',
+                all_methods        => { basic => [ 'basic01' ], extra => ['extra01', 'extra02'] },
+                initial_test_cases => [ 'basic01' ],
+                modifiers          => [ '', 'all', '-', 'basic' ],
+                expected           => [ 'extra01', 'extra02' ],
+            },
+        );
+        for my $case ( @cases ) {
+            subtest $case->{name} => sub {
+                my $test_cases = Zonemaster::CLI::TestCaseSet->new(    #
+                    $case->{initial_test_cases},
+                    %{ $case->{all_methods} },
+                );
+
+                while ( @{ $case->{modifiers} } ) {
+                    my $op   = shift @{ $case->{modifiers} };
+                    my $term = shift @{ $case->{modifiers} };
+                    $test_cases->apply_modifier( $op, $term );
+                }
+
+                eq_or_diff [ $test_cases->to_list ], $case->{expected};
+            };
+        }
+    };
+};
+
+for my $msg ( @{ $log->msgs } ) {
+    my $text = sprintf( "%s: %s", $msg->{level}, $msg->{message} );
+    if ( $msg->{level} =~ /trace|debug|info|notice/ ) {
+        note $text;
+    }
+    else {
+        diag $text;
+    }
+}
+
+Test::NoWarnings::had_no_warnings();
+done_testing;

--- a/t/test_case_set.t
+++ b/t/test_case_set.t
@@ -269,6 +269,13 @@ lives_ok {    # Make sure we get to print log messages in case of errors.
                 modifiers => [ '', 'all', '-', 'basic' ],
                 expected  => [ 'extra01', 'extra02' ],
             },
+            {
+                name      => 'invalid operator',
+                schema    => { basic => [ 'basic01', 'basic02' ] },
+                selection => ['basic01'],
+                modifiers => [ '*', 'basic02' ],
+                error     => qr{unrecognized operator}i,
+            },
         );
         for my $case ( @cases ) {
             subtest $case->{name} => sub {
@@ -277,15 +284,25 @@ lives_ok {    # Make sure we get to print log messages in case of errors.
                     $case->{schema},
                 );
 
-                while ( @{ $case->{modifiers} } ) {
-                    my $op   = shift @{ $case->{modifiers} };
-                    my $term = shift @{ $case->{modifiers} };
-                    $test_case_set->apply_modifier( $op, $term );
-                }
+                local $@ = '';
+                eval {
+                    while ( @{ $case->{modifiers} } ) {
+                        my $op   = shift @{ $case->{modifiers} };
+                        my $term = shift @{ $case->{modifiers} };
+                        $test_case_set->apply_modifier( $op, $term );
+                    }
+                };
+                my $error = $@;
 
-                eq_or_diff [ $test_case_set->to_list ], $case->{expected};
+                if ( exists $case->{expected} ) {
+                    is $error, '';
+                    eq_or_diff [ $test_case_set->to_list ], $case->{expected};
+                }
+                else {
+                    like $error, $case->{error};
+                }
             };
-        }
+        } ## end for my $case ( @cases )
     };
 };
 

--- a/t/test_case_set.t
+++ b/t/test_case_set.t
@@ -60,19 +60,19 @@ lives_ok {    # Make sure we get to print log messages in case of errors.
     subtest 'new' => sub {
         my @cases = (
             {
-                name               => 'empty',
-                all_methods        => {},
-                initial_test_cases => [],
-                expect_ok          => {
+                name      => 'empty',
+                schema    => {},
+                selection => [],
+                expect_ok => {
                     terms   => ['all'],
                     methods => [],
                 },
             },
             {
-                name               => 'multiple test modules and test cases',
-                all_methods        => { 'alpha' => [ 'bravo', 'charlie' ], 'delta' => ['echo'] },
-                initial_test_cases => [ 'bravo', 'echo' ],
-                expect_ok          => {
+                name      => 'multiple test modules and test cases',
+                schema    => { 'alpha' => [ 'bravo', 'charlie' ], 'delta' => ['echo'] },
+                selection => [ 'bravo', 'echo' ],
+                expect_ok => {
                     terms => [
                         'all',   'alpha',   'alpha/bravo', 'alpha/charlie',
                         'bravo', 'charlie', 'delta',       'delta/echo',
@@ -82,74 +82,107 @@ lives_ok {    # Make sure we get to print log messages in case of errors.
                 },
             },
             {
-                name               => 'illegal test module name 1',
-                all_methods        => { 'all' => [] },
-                initial_test_cases => [],
-                expect_err         => qr/must not be 'all'/i,
+                name      => 'mixed cases',
+                schema    => { 'alpha' => [ 'BRAVO', 'charlie' ] },
+                selection => [ 'bravo', 'CHARLIE' ],
+                expect_ok => {
+                    terms   => [ 'all',   'alpha', 'alpha/bravo', 'alpha/charlie', 'bravo', 'charlie' ],
+                    methods => [ 'bravo', 'charlie' ],
+                },
             },
             {
-                name               => 'illegal test module name 2',
-                all_methods        => { 'alpha/bravo' => [] },
-                initial_test_cases => [],
-                expect_err         => qr{contains forbidden character '/'}i,
+                name       => 'illegal test module name 1',
+                schema     => { 'all' => [] },
+                selection  => [],
+                expect_err => qr/must not be 'all'/i,
             },
             {
-                name               => 'illegal test case name 1',
-                all_methods        => { 'alpha' => ['all'] },
-                initial_test_cases => [],
-                expect_err         => qr/must not be 'all'/i,
+                name       => 'illegal test module name 2',
+                schema     => { 'ALL' => [] },
+                selection  => [],
+                expect_err => qr/must not be 'all'/i,
             },
             {
-                name               => 'illegal test case name 2',
-                all_methods        => { 'alpha' => ['bravo/charlie'] },
-                initial_test_cases => [],
-                expect_err         => qr{contains forbidden character '/'}i,
+                name       => 'illegal test module name 3',
+                schema     => { 'alpha/bravo' => [] },
+                selection  => [],
+                expect_err => qr{contains forbidden character '/'}i,
             },
             {
-                name               => 'duplicate term 1',
-                all_methods        => { 'alpha' => ['alpha'] },
-                initial_test_cases => [],
-                expect_err         => qr/same name/i,
+                name       => 'illegal test case name 1',
+                schema     => { 'alpha' => ['all'] },
+                selection  => [],
+                expect_err => qr/must not be 'all'/i,
             },
             {
-                name               => 'duplicate term 2',
-                all_methods        => { 'alpha' => [], 'bravo' => ['alpha'] },
-                initial_test_cases => [],
-                expect_err         => qr/same name/i,
+                name       => 'illegal test case name 2',
+                schema     => { 'alpha' => ['ALL'] },
+                selection  => [],
+                expect_err => qr/must not be 'all'/i,
             },
             {
-                name               => 'duplicate term 3',
-                all_methods        => { 'alpha' => [ 'bravo', 'bravo' ] },
-                initial_test_cases => [],
-                expect_err         => qr/same name/i,
+                name       => 'illegal test case name 3',
+                schema     => { 'alpha' => ['bravo/charlie'] },
+                selection  => [],
+                expect_err => qr{contains forbidden character '/'}i,
             },
             {
-                name               => 'duplicate term 4',
-                all_methods        => { 'alpha' => ['bravo'], 'charlie' => ['bravo'] },
-                initial_test_cases => [],
-                expect_err         => qr/same name/i,
+                name       => 'duplicate term 1',
+                schema     => { 'alpha' => ['alpha'] },
+                selection  => [],
+                expect_err => qr/same name/i,
             },
             {
-                name               => 'unrecognized test case 1',
-                all_methods        => { 'alpha' => [] },
-                initial_test_cases => ['all'],
-                expect_err         => qr/unrecognized/i,
+                name       => 'duplicate term 2',
+                schema     => { 'alpha' => ['ALPHA'] },
+                selection  => [],
+                expect_err => qr/same name/i,
             },
             {
-                name               => 'unrecognized test case 2',
-                all_methods        => { 'alpha' => [] },
-                initial_test_cases => ['alpha'],
-                expect_err         => qr/unrecognized/i,
+                name       => 'duplicate term 3',
+                schema     => { 'ALPHA' => ['alpha'] },
+                selection  => [],
+                expect_err => qr/same name/i,
+            },
+            {
+                name       => 'duplicate term 4',
+                schema     => { 'alpha' => [], 'bravo' => ['alpha'] },
+                selection  => [],
+                expect_err => qr/same name/i,
+            },
+            {
+                name       => 'duplicate term 5',
+                schema     => { 'alpha' => [ 'bravo', 'bravo' ] },
+                selection  => [],
+                expect_err => qr/same name/i,
+            },
+            {
+                name       => 'duplicate term 6',
+                schema     => { 'alpha' => ['bravo'], 'charlie' => ['bravo'] },
+                selection  => [],
+                expect_err => qr/same name/i,
+            },
+            {
+                name       => 'unrecognized test case 1',
+                schema     => { 'alpha' => [] },
+                selection  => ['all'],
+                expect_err => qr/unrecognized/i,
+            },
+            {
+                name       => 'unrecognized test case 2',
+                schema     => { 'alpha' => [] },
+                selection  => ['alpha'],
+                expect_err => qr/unrecognized/i,
             },
         );
         for my $case ( @cases ) {
             subtest $case->{name} => sub {
-                my $test_cases;
+                my $test_case_set;
                 local $@;
                 eval {
-                    $test_cases = Zonemaster::CLI::TestCaseSet->new(    #
-                        $case->{initial_test_cases},
-                        %{ $case->{all_methods} },
+                    $test_case_set = Zonemaster::CLI::TestCaseSet->new(    #
+                        $case->{selection},
+                        $case->{schema},
                     );
                 };
 
@@ -157,98 +190,100 @@ lives_ok {    # Make sure we get to print log messages in case of errors.
                 my $actual;
                 if ( !$err ) {
                     $actual = {
-                        terms   => [ sort keys %{ $test_cases->{_all_term_methods} } ],
-                        methods => [ $test_cases->to_list ],
+                        terms   => [ sort keys %{ $test_case_set->{_terms} } ],
+                        methods => [ $test_case_set->to_list ],
                     };
                 }
 
                 if ( defined $case->{expect_err} ) {
                     like $err, $case->{expect_err}, "error";
-                } else {
+                }
+                else {
                     is $err, "", "no error";
                 }
                 if ( defined $case->{expect_ok} ) {
                     eq_or_diff $actual, $case->{expect_ok}, "result";
-                } else {
+                }
+                else {
                     eq_or_diff $actual, undef, "no result";
                 }
-            }; ## end sub
+            };    ## end sub
         } ## end for my $case ( @cases )
-    }; ## end 'new' => sub
+    };    ## end 'new' => sub
 
     subtest 'apply_modifier' => sub {
         my @cases = (
             {
-                name               => 'empty',
-                all_methods        => {},
-                initial_test_cases => [],
-                modifiers          => [],
-                expected           => [],
+                name      => 'empty',
+                schema    => {},
+                selection => [],
+                modifiers => [],
+                expected  => [],
             },
             {
-                name               => 'no modifiers',
-                all_methods        => { basic => [ 'basic01', 'basic02' ] },
-                initial_test_cases => [ 'basic01' ],
-                modifiers          => [],
-                expected           => [ 'basic01' ],
+                name      => 'no modifiers',
+                schema    => { basic => [ 'basic01', 'basic02' ] },
+                selection => ['basic01'],
+                modifiers => [],
+                expected  => ['basic01'],
             },
             {
-                name               => 'add a new case',
-                all_methods        => { basic => [ 'basic01', 'basic02' ] },
-                initial_test_cases => [ 'basic01' ],
-                modifiers          => [ '+', 'basic02' ],
-                expected           => [ 'basic01', 'basic02' ],
+                name      => 'add a new case',
+                schema    => { basic => [ 'basic01', 'basic02' ] },
+                selection => ['basic01'],
+                modifiers => [ '+',       'basic02' ],
+                expected  => [ 'basic01', 'basic02' ],
             },
             {
-                name               => 'add the same case',
-                all_methods        => { basic => [ 'basic01', 'basic02' ] },
-                initial_test_cases => [ 'basic01' ],
-                modifiers          => [ '+', 'basic01' ],
-                expected           => [ 'basic01' ],
+                name      => 'add the same case',
+                schema    => { basic => [ 'basic01', 'basic02' ] },
+                selection => ['basic01'],
+                modifiers => [ '+', 'basic01' ],
+                expected  => ['basic01'],
             },
             {
-                name               => 'replace',
-                all_methods        => { basic => [ 'basic01', 'basic02' ] },
-                initial_test_cases => [ 'basic01' ],
-                modifiers          => [ '', 'basic02' ],
-                expected           => [ 'basic02' ],
+                name      => 'replace',
+                schema    => { basic => [ 'basic01', 'basic02' ] },
+                selection => ['basic01'],
+                modifiers => [ '', 'basic02' ],
+                expected  => ['basic02'],
             },
             {
-                name               => 'module expansion',
-                all_methods        => { basic => [ 'basic01' ], extra => ['extra01', 'extra02'] },
-                initial_test_cases => [ 'basic01' ],
-                modifiers          => [ '', 'extra' ],
-                expected           => [ 'extra01', 'extra02' ],
+                name      => 'module expansion',
+                schema    => { basic => ['basic01'], extra => [ 'extra01', 'extra02' ] },
+                selection => ['basic01'],
+                modifiers => [ '',        'extra' ],
+                expected  => [ 'extra01', 'extra02' ],
             },
             {
-                name               => 'all',
-                all_methods        => { basic => [ 'basic01' ], extra => ['extra01', 'extra02'] },
-                initial_test_cases => [ 'basic01' ],
-                modifiers          => [ '', 'all' ],
-                expected           => [ 'basic01', 'extra01', 'extra02' ],
+                name      => 'all',
+                schema    => { basic => ['basic01'], extra => [ 'extra01', 'extra02' ] },
+                selection => ['basic01'],
+                modifiers => [ '', 'all' ],
+                expected  => [ 'basic01', 'extra01', 'extra02' ],
             },
             {
-                name               => 'multiple modifiers',
-                all_methods        => { basic => [ 'basic01' ], extra => ['extra01', 'extra02'] },
-                initial_test_cases => [ 'basic01' ],
-                modifiers          => [ '', 'all', '-', 'basic' ],
-                expected           => [ 'extra01', 'extra02' ],
+                name      => 'multiple modifiers',
+                schema    => { basic => ['basic01'], extra => [ 'extra01', 'extra02' ] },
+                selection => ['basic01'],
+                modifiers => [ '', 'all', '-', 'basic' ],
+                expected  => [ 'extra01', 'extra02' ],
             },
         );
         for my $case ( @cases ) {
             subtest $case->{name} => sub {
-                my $test_cases = Zonemaster::CLI::TestCaseSet->new(    #
-                    $case->{initial_test_cases},
-                    %{ $case->{all_methods} },
+                my $test_case_set = Zonemaster::CLI::TestCaseSet->new(    #
+                    $case->{selection},
+                    $case->{schema},
                 );
 
                 while ( @{ $case->{modifiers} } ) {
                     my $op   = shift @{ $case->{modifiers} };
                     my $term = shift @{ $case->{modifiers} };
-                    $test_cases->apply_modifier( $op, $term );
+                    $test_case_set->apply_modifier( $op, $term );
                 }
 
-                eq_or_diff [ $test_cases->to_list ], $case->{expected};
+                eq_or_diff [ $test_case_set->to_list ], $case->{expected};
             };
         }
     };

--- a/t/usage.t
+++ b/t/usage.t
@@ -97,7 +97,7 @@ sub check_success {
         }
 
         is $exitstatus, $Zonemaster::CLI::EXIT_SUCCESS, 'success exit status';
-    };
+    }; ## end sub
 } ## end sub check_success
 
 sub check_success_report {
@@ -510,15 +510,16 @@ do {
 
     check_usage_error 'unrecognized option', ['--foobar'], qr{unknown option}i;
 
-    check_usage_error '--test BAD_MODULE', [ '--test', '!%~&', 'example.' ], qr{invalid input}i;
+    check_usage_error '--test BAD_MODULE', [ '--test', '!%~&', 'example.' ], qr{unrecognized term '!%~&' in --test}i;
 
     check_usage_error '--test UNKNOWN_MODULE/TESTCASE', [ '--test', 'foobar/foobar01', 'example.' ],
-      qr{unrecognized test module}i;
+      qr{unrecognized term 'foobar/foobar01' in --test}i;
 
     check_usage_error '--test MODULE/UNKNOWN_TESTCASE', [ '--test', 'basic/foobar01', 'example.' ],
-      qr{unrecognized test case}i;
+      qr{unrecognized term 'basic/foobar01' in --test}i;
 
-    check_usage_error '--test MODULE//TESTCASE', [ '--test', 'basic//basic01', 'example.' ], qr{invalid input}i;
+    check_usage_error '--test MODULE//TESTCASE', [ '--test', 'basic//basic01', 'example.' ],
+      qr{unrecognized term 'basic//basic01' in --test}i;
 
     check_usage_error '--ns BAD_NAME', [ '--ns', '!%~&', 'example.' ], qr{invalid name}i;
 
@@ -646,6 +647,26 @@ do {
         my $source6 = $profile->{resolver}{source6} // '<missing>';
 
         return $source6 eq '2001:db8::2';
+      };
+
+    check_success 'override test_cases',
+      [ '--dump-profile', '--profile=t/usage.profile', '--test=basic01' ], sub {
+        my ( $profile ) = parse_json_stream( $_[0] );
+
+        return
+             ref $profile->{test_cases} eq 'ARRAY'
+          && scalar @{ $profile->{test_cases} } == 1
+          && $profile->{test_cases}[0] eq 'basic01';
+      };
+
+    check_success 'override test_cases twice',
+      [ '--dump-profile', '--profile=t/usage.profile', '--test=-all', '--test=+basic01' ], sub {
+        my ( $profile ) = parse_json_stream( $_[0] );
+
+        return
+             ref $profile->{test_cases} eq 'ARRAY'
+          && scalar @{ $profile->{test_cases} } == 1
+          && $profile->{test_cases}[0] eq 'basic01';
       };
 
     check_success '--restore', [ "--restore=$PATH_NORMAL_DATAFILE", '--test=basic01', '--level=INFO', '--raw', '.' ],


### PR DESCRIPTION
## Purpose

This PR implements flexible command line overriding of which test cases to run from the command line.

## Context

* This is an extension to the improvements in #333.

* Replaces #130. The point of that PR is to allow users to exclude test cases from the command line. This PR includes the same functionality using a different command line syntax.

* Leverages zonemaster/zonemaster-engine#1312 to properly handle the Basic test module (c.f. https://github.com/zonemaster/zonemaster-cli/pull/130#issuecomment-572948201).

* Handles the interaction of `--test` and `--profile` in accordance with https://github.com/zonemaster/zonemaster-cli/pull/130#issuecomment-573012219.

* For what it's worth, the idea for this design came to me in a discussion about https://github.com/zonemaster/zonemaster-engine/pull/1294.

## Changes

* The set of values accepted by `--test` is extended.

* Which test cases to include in the run is now controlled by setting the `test_cases` profile property and running Zonemaster::Engine->test_zone().

* When `--test=basic` or `--test=basic02` is specified, and basic02 considers the domain too broken to test, a CANNOT_CONTINUE message is now emitted, whereas it wasn't emitted before this PR.

## Reviewing

* Look especially for lacking test coverage.

## Testing

* Unit tests should pass.