### PR TITLE
CI: update versions and dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
-dist: focal
+dist: jammy
 
 language: perl
 
 perl:
-    - "5.32"
-    - "5.30.2"
+    - "5.36"
+    - "5.30"
     - "5.26"
-    - "5.14.4"
 
 addons:
   apt:
@@ -26,6 +25,7 @@ addons:
     - liblist-moreutils-perl
     - liblocale-msgfmt-perl
     - libmail-rfc822-address-perl
+    - libmail-spf-perl
     - libmodule-find-perl
     - libnet-ip-perl
     - libpod-coverage-perl


### PR DESCRIPTION
## Purpose

This PR updates Travis CI in CLI by updating the Perl versions, distribution version and adding missing dependency Mail::SPF.

## Context

New Perl and distribution versions in Engine added by https://github.com/zonemaster/zonemaster-engine/pull/1305
New dependency in Engine added by https://github.com/zonemaster/zonemaster-engine/pull/1287

## Changes

* Test against Perl 5.36, 5.30 and 5.26 instead of 5.32, 5.30.2 and 5.14.4;
* Test using Ubuntu 22.04 LTS (jammy)

## How to test this PR

Travis should pass.
