### PR TITLE
Remove planned deprecated '--sourceaddr' option

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -275,26 +275,13 @@ has 'dump_profile' => (
     documentation => __( 'Print the effective profile used in JSON format, then exit.' ),
 );
 
-has 'sourceaddr' => (
-    is            => 'ro',
-    isa           => 'Str',
-    required      => 0,
-    documentation => __(
-            'Deprecated (planned removal: v2024.1). '
-          . 'Use --sourceaddr4 and/or --sourceaddr6. '
-          . 'Source IP address used to send queries. '
-          . 'Setting an IP address not correctly configured on a local network interface causes cryptic error messages.'
-    ),
-);
-
 has 'sourceaddr4' => (
     is            => 'ro',
     isa           => 'Str',
     required      => 0,
     documentation => __(
             'Source IPv4 address used to send queries. '
-          . 'Setting an IPv4 address not correctly configured on a local network interface fails silently. '
-          . 'Can not be combined with --sourceaddr.'
+          . 'Setting an IPv4 address not correctly configured on a local network interface fails silently.'
     ),
 );
 
@@ -304,8 +291,7 @@ has 'sourceaddr6' => (
     required      => 0,
     documentation => __(
             'Source IPv6 address used to send queries. '
-          . 'Setting an IPv6 address not correctly configured on a local network interface fails silently. '
-          . 'Can not be combined with --sourceaddr.'
+          . 'Setting an IPv6 address not correctly configured on a local network interface fails silently.'
     ),
 );
 
@@ -351,14 +337,6 @@ sub run {
 
     if ( $self->list_tests ) {
         print_test_list();
-    }
-
-    if ( $self->sourceaddr ) {
-        if ( $self->sourceaddr4 or $self->sourceaddr6 ) {
-            die __( "Error: --sourceaddr can't be combined with --sourceaddr4 or --sourceaddr6." ) . "\n";
-        }
-        printf STDERR "%s\n\n", __( "Warning: --sourceaddr is deprecated (planned removal: v2024.1). Use --sourceaddr4 and/or --sourceaddr6 instead." );
-        Zonemaster::Engine::Profile->effective->set( q{resolver.source}, $self->sourceaddr );
     }
 
     if ( $self->sourceaddr4 ) {

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -256,26 +256,17 @@ name servers took to answer.
 
 Print the effective profile used in JSON format, then exit.
 
-=item --sourceaddr=IPADDR
-
-Deprecated since v2023.1 (planned removal: v2024.1), use --sourceaddr4
-and/or --sourceaddr6 instead.
-
-Specify the source IP address used to send queries.
-Setting an IP address not correctly configured on a local network interface
-causes cryptic error messages.
-
 =item --sourceaddr4=IPADDR
 
 Specify the source IPv4 address used to send queries.
 Setting an IPv4 address not correctly configured on a local network interface
-fails silently. Can not be combined with --sourceaddr.
+fails silently.
 
 =item --sourceaddr6=IPADDR
 
 Specify the source IPv6 address used to send queries.
 Setting an IPv6 address not correctly configured on a local network interface
-fails silently. Can not be combined with --sourceaddr.
+fails silently.
 
 =item --[no-]elapsed
 


### PR DESCRIPTION
## Purpose

This PR removes planned deprecated `--sourceaddr` option.

## Context

Relates to https://github.com/zonemaster/zonemaster-engine/pull/1343

## How to test this PR

There should be no trace in the code, or documentation of the `--sourceaddr` option.

Also:
```
$ zonemaster-cli zonemaster.net --sourceaddr 1.2.3.4
Unknown option: --sourceaddr
Run "zonemaster-cli -h" to get the valid options
```
