### PR TITLE
Remove duplicate function calls

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -617,14 +617,6 @@ sub run {
         print $header;
     }
 
-    if ( @opt_ns ) {
-        add_fake_delegation( $domain, @opt_ns );
-    }
-
-    if ( @opt_ds ) {
-        add_fake_ds( $domain, @opt_ds );
-    }
-
     # Now we are ready to actually print messages, including those that are
     # currently in the hold queue.
     while (my $entry = pop @held_messages) {


### PR DESCRIPTION
## Purpose

This PR removes two duplicate function calls. The first calls are made several lines above. This looks like it was a mistake after a mixup between two commits: https://github.com/zonemaster/zonemaster-cli/commit/72f1ec27354f568dd46950cc13186e9a40ef0074 and https://github.com/zonemaster/zonemaster-cli/commit/3985220077e60b738074f87be77f3c6472b675d9 in release v2024.2.

## How to test this PR

Tests should pass.
With manual testing, undelegated tests should still work:
```
$ zonemaster-cli --level INFO --ns ns2.nic.fr zonemaster.net --test basic --show-testcase --no-ipv6

Seconds Level    Testcase       Message
======= ======== ============== =======
   0.00 INFO     Unspecified    Using version v7.0.0 of the Zonemaster engine.
   0.00 INFO     Basic01        The zone "zonemaster.net" is found.
   0.00 INFO     Basic01        This is a test of an undelegated domain so finding the parent zone is disregarded.
   0.04 INFO     Basic02        Authoritative answer on SOA query for "zonemaster.net" is returned by name servers "ns2.nic.fr/192.93.0.4".
   0.04 INFO     Unspecified    Functional nameserver found. "A" query for www.zonemaster.net test skipped.
```