### PR TITLE
Expand --nstimes option

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -9,7 +9,6 @@ package Zonemaster::CLI;
 
 use v5.26;
 
-use strict;
 use warnings;
 
 use version; our $VERSION = version->declare( "v7.2.0" );
@@ -646,17 +645,16 @@ sub run {
         my %all_nss = %{ Zonemaster::Engine::Nameserver::object_cache };
         my @child_nss = @{ $zone->ns };
         my @parent_nss = @{ $zone->parent->ns };
-        my @nss;
+        my @all_responded_nss;
 
         foreach my $ns_name ( keys %all_nss ) {
             foreach my $ns ( values %{ $all_nss{$ns_name} } ) {
-                push @nss, $ns if scalar @{ $ns->times } > 0;
+                push @all_responded_nss, $ns if scalar @{ $ns->times } > 0;
             }
         }
 
-        my %nss_filter;
-        @nss_filter{ ( @child_nss, @parent_nss ) } = undef;
-        my @other_nss = grep { ! exists $nss_filter{$_} } @nss;
+        my %nss_filter = map { $_ => undef } ( @child_nss, @parent_nss );
+        my @other_nss = grep { ! exists $nss_filter{$_} } @all_responded_nss;
 
         if ( $opt_json ) {
             my @times;
@@ -690,7 +688,7 @@ sub run {
         }
         else {
             my $header = __( 'Name servers' );
-            my $max = max map { length( "$_" ) } ( ( @child_nss, @parent_nss, @nss ), $header );
+            my $max = max map { length( "$_" ) } ( ( @child_nss, @parent_nss, @all_responded_nss ), $header );
             printf "\n%${max}s %s\n", $header, '        Max        Min        Avg     Stddev     Median       Total       Count';
             printf "%${max}s %s\n", '=' x $max, ' ========== ========== ========== ========== ========== =========== ===========';
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -644,22 +644,22 @@ sub run {
     if ( $opt_nstimes ) {
         my $zone = Zonemaster::Engine->zone( $domain );
         my %all_nss = %{ Zonemaster::Engine::Nameserver::object_cache };
-        my @zone_nss = @{ $zone->ns };
+        my @child_nss = @{ $zone->ns };
         my @parent_nss = @{ $zone->parent->ns };
         my @nss;
 
-        foreach my $keys ( keys %all_nss ) {
-            foreach my $val ( values %{ $all_nss{$keys} } ) {
-                push @nss, $val if scalar @{ $val->times } > 0;
+        foreach my $ns_name ( keys %all_nss ) {
+            foreach my $ns ( values %{ $all_nss{$ns_name} } ) {
+                push @nss, $ns if scalar @{ $ns->times } > 0;
             }
         }
 
         my %nss_filter;
-        @nss_filter{ ( @zone_nss, @parent_nss ) } = ();
-        my @filtered_nss = grep { ! exists $nss_filter{$_} } @nss;
+        @nss_filter{ ( @child_nss, @parent_nss ) } = undef;
+        my @other_nss = grep { ! exists $nss_filter{$_} } @nss;
 
         if ( $opt_json ) {
-            my ( @times, @items ) = ();
+            my @times;
 
             sub json_nstimes {
                 my ( $ns ) = @_;
@@ -674,75 +674,71 @@ sub run {
                     'count' => scalar @{ $ns->times } };
             }
 
-            foreach my $ns ( sort @zone_nss ) {
-                push @items, json_nstimes( $ns );
+            if ( @child_nss ) {
+                my @entries = map { json_nstimes( $_ ) } sort @child_nss;
+                push @times, { 'zone' => \@entries };
             }
-            push @times, { 'zone' => \@items } if scalar @items;
-            @items = ();
 
-            foreach my $ns ( sort @parent_nss ) {
-                push @items, json_nstimes( $ns );
+            if ( @parent_nss ) {
+                my @entries = map { json_nstimes( $_ ) } sort @parent_nss;
+                push @times, { 'parent' => \@entries };
             }
-            push @times, { 'parent' => \@items } if scalar @items;
-            @items = ();
 
-            foreach my $ns ( sort @filtered_nss ) {
-                push @items, json_nstimes( $ns );
+            if ( @other_nss ) {
+                my @entries = map { json_nstimes( $_ ) } sort @other_nss;
+                push @times, { 'other' => \@entries };
             }
-            push @times, { 'other' => \@items } if scalar @items;
 
             $json_output->{nstimes} = \@times;
         }
         else {
-            my $max = max map { length( "$_" ) } ( uniq ( @zone_nss, @parent_nss, @nss ), q{Server} );
+            my $header = __( 'Name servers' );
+            my $max = max map { length( "$_" ) } ( ( @child_nss, @parent_nss, @nss ), $header );
             print "\n";
-            printf __("%${max}s %s\n"), 'Server', '      Max      Min      Avg   Stddev   Median     Total     Count';
-            printf "%${max}s %s\n", '=' x $max, ' ======== ======== ======== ======== ======== ========= =========';
+            printf "%${max}s %s\n", $header, '        Max        Min        Avg     Stddev     Median       Total       Count';
+            printf "%${max}s %s\n", '=' x $max, ' ========== ========== ========== ========== ========== =========== ===========';
 
             my $total_queries_count = 0;
             my $total_queries_times = 0;
             my %nss_already_processed;
 
             sub print_nstimes {
-                my ( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed ) = @_;
+                my ( $ns, $max, $total_queries_count, $total_queries_times, $nss_already_processed_ref ) = @_;
+                my %nss_already_processed = %{ $nss_already_processed_ref };
 
                 printf "%${max}s ", $ns->string;
-                printf "%9.2f ",    1000 * $ns->max_time;
-                printf "%8.2f ",    1000 * $ns->min_time;
-                printf "%8.2f ",    1000 * $ns->average_time;
-                printf "%8.2f ",    1000 * $ns->stddev_time;
-                printf "%8.2f ",    1000 * $ns->median_time;
-                printf "%9.2f ",    1000 * $ns->sum_time;
-                printf "%9d\n",     scalar @{ $ns->times };
+                printf "%11.2f ",    1000 * $ns->max_time;
+                printf "%10.2f ",    1000 * $ns->min_time;
+                printf "%10.2f ",    1000 * $ns->average_time;
+                printf "%10.2f ",    1000 * $ns->stddev_time;
+                printf "%10.2f ",    1000 * $ns->median_time;
+                printf "%11.2f ",    1000 * $ns->sum_time;
+                printf "%11d\n",     scalar @{ $ns->times };
                 $total_queries_count += scalar @{ $ns->times } unless $nss_already_processed{$ns};
                 $total_queries_times += ( 1000 * $ns->sum_time ) unless $nss_already_processed{$ns};
 
-                return $total_queries_count, $total_queries_times, %nss_already_processed;
+                return $total_queries_count, $total_queries_times;
             }
 
-            printf __("%s %s\n"), 'Child', '-' x ( ( $max - length 'Child' ) - 1 );
-            foreach my $ns ( sort @zone_nss ) {
-                ( $total_queries_count, $total_queries_times, %nss_already_processed ) =
-                    print_nstimes( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed );
-                $nss_already_processed{$ns} = 1;
+            my %section_mapping = (
+                1 => { __( 'Child zone' ) => \@child_nss },
+                2 => { __( 'Parent zone' ) => \@parent_nss },
+                3 => { __( 'Other' ) => \@other_nss }
+            );
+
+            foreach my $section_order ( sort keys %section_mapping ) {
+                foreach my $section_header ( keys % { $section_mapping{$section_order} } ) {
+                    printf "%s %s\n", $section_header, '-' x ( ( $max - length $section_header ) - 1 );
+                    foreach my $section_nss ( sort @{ $section_mapping{$section_order}{$section_header} } ) {
+                        ( $total_queries_count, $total_queries_times ) =
+                            print_nstimes( $section_nss, $max, $total_queries_count, $total_queries_times, \%nss_already_processed );
+                        $nss_already_processed{$section_nss} = 1;
+                    }
+                }
             }
 
-            printf __("%s %s\n"), 'Parent', '-' x ( ( $max - length 'Parent' ) - 1 );
-            foreach my $ns ( sort @parent_nss ) {
-                ( $total_queries_count, $total_queries_times, %nss_already_processed ) =
-                    print_nstimes( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed );
-                $nss_already_processed{$ns} = 1;
-            }
-
-            printf __("%s %s\n"), 'Other', '-' x ( ( $max - length 'Other' ) - 1 );
-            foreach my $ns ( sort @filtered_nss ) {
-                ( $total_queries_count, $total_queries_times, %nss_already_processed ) =
-                    print_nstimes( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed );
-                $nss_already_processed{$ns} = 1;
-            }
-
-            printf "%${max}s %s\n", '=' x $max, ' ======== ======== ======== ======== ======== ========= =========';
-            printf __("%${max}s %55.2f %9s\n"), 'Total', $total_queries_times, $total_queries_count;
+            printf "%${max}s %s\n", '=' x $max, ' ========== ========== ========== ========== ========== =========== ===========';
+            printf "%${max}s %67.2f %11s\n", __( 'Grand total' ), $total_queries_times, $total_queries_count;
         }
     } ## end if ( $opt_nstimes )
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -1,13 +1,13 @@
 # Brief help module to define the exception we use for early exits.
 package Zonemaster::Engine::Exception::NormalExit;
-use 5.014002;
+use v5.26;
 use warnings;
 use parent 'Zonemaster::Engine::Exception';
 
 # The actual interesting module.
 package Zonemaster::CLI;
 
-use 5.014002;
+use v5.26;
 
 use strict;
 use warnings;
@@ -661,7 +661,7 @@ sub run {
         if ( $opt_json ) {
             my @times;
 
-            sub json_nstimes {
+            my sub json_nstimes {
                 my ( $ns ) = @_;
                 return {
                     'ns'      => $ns->string,
@@ -698,7 +698,7 @@ sub run {
             my $total_queries_times = 0;
             my %nss_already_processed;
 
-            sub print_nstimes {
+            my sub print_nstimes {
                 my ( $ns, $max, $total_queries_count, $total_queries_times, $nss_already_processed_ref ) = @_;
                 my %nss_already_processed = %{ $nss_already_processed_ref };
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -643,38 +643,106 @@ sub run {
 
     if ( $opt_nstimes ) {
         my $zone = Zonemaster::Engine->zone( $domain );
-        my $max  = max map { length( "$_" ) } ( @{ $zone->ns }, q{Server} );
+        my %all_nss = %{ Zonemaster::Engine::Nameserver::object_cache };
+        my @zone_nss = @{ $zone->ns };
+        my @parent_nss = @{ $zone->parent->ns };
+        my @nss;
+
+        foreach my $keys ( keys %all_nss ) {
+            foreach my $val ( values %{ $all_nss{$keys} } ) {
+                push @nss, $val if scalar @{ $val->times } > 0;
+            }
+        }
+
+        my %nss_filter;
+        @nss_filter{ ( @zone_nss, @parent_nss ) } = ();
+        my @filtered_nss = grep { ! exists $nss_filter{$_} } @nss;
 
         if ( $opt_json ) {
-            my @times = ();
-            foreach my $ns ( @{ $zone->ns } ) {
-                push @times,
-                  {
-                    'ns'     => $ns->string,
-                    'max'    => 1000 * $ns->max_time,
-                    'min'    => 1000 * $ns->min_time,
-                    'avg'    => 1000 * $ns->average_time,
-                    'stddev' => 1000 * $ns->stddev_time,
-                    'median' => 1000 * $ns->median_time,
-                    'total'  => 1000 * $ns->sum_time
-                  };
+            my ( @times, @items ) = ();
+
+            sub json_nstimes {
+                my ( $ns ) = @_;
+                return {
+                    'ns'      => $ns->string,
+                    'max'     => 1000 * $ns->max_time,
+                    'min'     => 1000 * $ns->min_time,
+                    'avg'     => 1000 * $ns->average_time,
+                    'stddev'  => 1000 * $ns->stddev_time,
+                    'median'  => 1000 * $ns->median_time,
+                    'total'   => 1000 * $ns->sum_time,
+                    'count' => scalar @{ $ns->times } };
             }
+
+            foreach my $ns ( sort @zone_nss ) {
+                push @items, json_nstimes( $ns );
+            }
+            push @times, { 'zone' => \@items } if scalar @items;
+            @items = ();
+
+            foreach my $ns ( sort @parent_nss ) {
+                push @items, json_nstimes( $ns );
+            }
+            push @times, { 'parent' => \@items } if scalar @items;
+            @items = ();
+
+            foreach my $ns ( sort @filtered_nss ) {
+                push @items, json_nstimes( $ns );
+            }
+            push @times, { 'other' => \@items } if scalar @items;
+
             $json_output->{nstimes} = \@times;
         }
         else {
+            my $max = max map { length( "$_" ) } ( uniq ( @zone_nss, @parent_nss, @nss ), q{Server} );
             print "\n";
-            printf "%${max}s %s\n", 'Server',   '      Max      Min      Avg   Stddev   Median     Total';
-            printf "%${max}s %s\n", '=' x $max, ' ======== ======== ======== ======== ======== =========';
+            printf __("%${max}s %s\n"), 'Server', '      Max      Min      Avg   Stddev   Median     Total     Count';
+            printf "%${max}s %s\n", '=' x $max, ' ======== ======== ======== ======== ======== ========= =========';
 
-            foreach my $ns ( @{ $zone->ns } ) {
+            my $total_queries_count = 0;
+            my $total_queries_times = 0;
+            my %nss_already_processed;
+
+            sub print_nstimes {
+                my ( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed ) = @_;
+
                 printf "%${max}s ", $ns->string;
                 printf "%9.2f ",    1000 * $ns->max_time;
                 printf "%8.2f ",    1000 * $ns->min_time;
                 printf "%8.2f ",    1000 * $ns->average_time;
                 printf "%8.2f ",    1000 * $ns->stddev_time;
                 printf "%8.2f ",    1000 * $ns->median_time;
-                printf "%9.2f\n",   1000 * $ns->sum_time;
+                printf "%9.2f ",    1000 * $ns->sum_time;
+                printf "%9d\n",     scalar @{ $ns->times };
+                $total_queries_count += scalar @{ $ns->times } unless $nss_already_processed{$ns};
+                $total_queries_times += ( 1000 * $ns->sum_time ) unless $nss_already_processed{$ns};
+
+                return $total_queries_count, $total_queries_times, %nss_already_processed;
             }
+
+            printf __("%s %s\n"), 'Child', '-' x ( ( $max - length 'Child' ) - 1 );
+            foreach my $ns ( sort @zone_nss ) {
+                ( $total_queries_count, $total_queries_times, %nss_already_processed ) =
+                    print_nstimes( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed );
+                $nss_already_processed{$ns} = 1;
+            }
+
+            printf __("%s %s\n"), 'Parent', '-' x ( ( $max - length 'Parent' ) - 1 );
+            foreach my $ns ( sort @parent_nss ) {
+                ( $total_queries_count, $total_queries_times, %nss_already_processed ) =
+                    print_nstimes( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed );
+                $nss_already_processed{$ns} = 1;
+            }
+
+            printf __("%s %s\n"), 'Other', '-' x ( ( $max - length 'Other' ) - 1 );
+            foreach my $ns ( sort @filtered_nss ) {
+                ( $total_queries_count, $total_queries_times, %nss_already_processed ) =
+                    print_nstimes( $ns, $max, $total_queries_count, $total_queries_times, %nss_already_processed );
+                $nss_already_processed{$ns} = 1;
+            }
+
+            printf "%${max}s %s\n", '=' x $max, ' ======== ======== ======== ======== ======== ========= =========';
+            printf __("%${max}s %55.2f %9s\n"), 'Total', $total_queries_times, $total_queries_count;
         }
     } ## end if ( $opt_nstimes )
 
@@ -685,7 +753,7 @@ sub run {
             $json_output->{elapsed} = $last->timestamp;
         }
         else {
-            printf "Total test run time: %0.1f seconds.\n", $last->timestamp;
+            printf "\nTotal test run time: %0.1f seconds.\n", $last->timestamp;
         }
     }
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -671,22 +671,19 @@ sub run {
                     'stddev'  => 1000 * $ns->stddev_time,
                     'median'  => 1000 * $ns->median_time,
                     'total'   => 1000 * $ns->sum_time,
-                    'count' => scalar @{ $ns->times } };
+                    'count'   => scalar @{ $ns->times }
+                };
             }
 
-            if ( @child_nss ) {
-                my @entries = map { json_nstimes( $_ ) } sort @child_nss;
-                push @times, { 'zone' => \@entries };
-            }
+            my %section_mapping = (
+                'child' => \@child_nss,
+                'parent' => \@parent_nss,
+                'other' => \@other_nss
+            );
 
-            if ( @parent_nss ) {
-                my @entries = map { json_nstimes( $_ ) } sort @parent_nss;
-                push @times, { 'parent' => \@entries };
-            }
-
-            if ( @other_nss ) {
-                my @entries = map { json_nstimes( $_ ) } sort @other_nss;
-                push @times, { 'other' => \@entries };
+            foreach my $section_name ( sort keys %section_mapping ) {
+                my @entries = map { json_nstimes( $_ ) } sort @{ $section_mapping{$section_name} };
+                push @times, { $section_name => \@entries };
             }
 
             $json_output->{nstimes} = \@times;
@@ -694,8 +691,7 @@ sub run {
         else {
             my $header = __( 'Name servers' );
             my $max = max map { length( "$_" ) } ( ( @child_nss, @parent_nss, @nss ), $header );
-            print "\n";
-            printf "%${max}s %s\n", $header, '        Max        Min        Avg     Stddev     Median       Total       Count';
+            printf "\n%${max}s %s\n", $header, '        Max        Min        Avg     Stddev     Median       Total       Count';
             printf "%${max}s %s\n", '=' x $max, ' ========== ========== ========== ========== ========== =========== ===========';
 
             my $total_queries_count = 0;
@@ -706,7 +702,7 @@ sub run {
                 my ( $ns, $max, $total_queries_count, $total_queries_times, $nss_already_processed_ref ) = @_;
                 my %nss_already_processed = %{ $nss_already_processed_ref };
 
-                printf "%${max}s ", $ns->string;
+                printf "%${max}s ",  $ns->string;
                 printf "%11.2f ",    1000 * $ns->max_time;
                 printf "%10.2f ",    1000 * $ns->min_time;
                 printf "%10.2f ",    1000 * $ns->average_time;
@@ -729,6 +725,7 @@ sub run {
             foreach my $section_order ( sort keys %section_mapping ) {
                 foreach my $section_header ( keys % { $section_mapping{$section_order} } ) {
                     printf "%s %s\n", $section_header, '-' x ( ( $max - length $section_header ) - 1 );
+
                     foreach my $section_nss ( sort @{ $section_mapping{$section_order}{$section_header} } ) {
                         ( $total_queries_count, $total_queries_times ) =
                             print_nstimes( $section_nss, $max, $total_queries_count, $total_queries_times, \%nss_already_processed );

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -302,8 +302,8 @@ level that were logged during the run, as well as a count of each message tag.
 
 =item B<--[no-]nstimes>
 
-Print a summary, at the end of a run, of the times (in milliseconds) the zone's
-name servers took to answer.
+Print a summary, at the end of a run, of the times (in milliseconds) the name servers
+took to answer, as well as the number of sent queries.
 (default: disabled)
 
 =item B<--[no-]elapsed>

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -302,8 +302,9 @@ level that were logged during the run, as well as a count of each message tag.
 
 =item B<--[no-]nstimes>
 
-Print a summary, at the end of a run, of the times (in milliseconds) the name servers
-took to answer, as well as the number of sent queries.
+Print a summary, at the end of a run, of various metrics related to the times
+(in milliseconds) each name server took to answer, as well as a count of the
+number of sent queries per name server.
 (default: disabled)
 
 =item B<--[no-]elapsed>

--- a/t/usage.t
+++ b/t/usage.t
@@ -390,9 +390,15 @@ do {
         text => qr{
             \QLooks OK.\E
             .*
-            Server \s+ Max \s+ Min \s+ Avg \s+ Stddev \s+ Median \s+ Total
+            \QName servers\E \s+ Max \s+ Min \s+ Avg \s+ Stddev \s+ Median \s+ Total \s+ Count
             .*
-            \Qa.root-servers.net/\E
+            \QChild zone\E
+            .*
+            \QParent zone\E
+            .*
+            Other
+            .*
+            \QGrand total\E \s+ \d+
         }msx,
         json => {
             type       => "object",
@@ -401,8 +407,30 @@ do {
                 nstimes => {
                     type  => "array",
                     items => {
-                        type     => "object",
-                        required => [qw( avg max median min ns stddev total)],
+                        type       => "object",
+                        properties => {
+                            child => {
+                                type  => "array",
+                                items => {
+                                    type     => "object",
+                                    required => [qw( avg max median min ns stddev total count)],
+                                },
+                            },
+                            parent => {
+                                type  => "array",
+                                items => {
+                                    type     => "object",
+                                    required => [qw( avg max median min ns stddev total count)],
+                                },
+                            },
+                            other => {
+                                type  => "array",
+                                items => {
+                                    type     => "object",
+                                    required => [qw( avg max median min ns stddev total count)],
+                                },
+                            },
+                        },
                     },
                 },
             },


### PR DESCRIPTION
## Purpose

This PR proposes to expand the `--nstimes` option in several ways. See the "Changes" section below.

Note: this option applies only to "sent" queries. Cached queries are not counted.

## Context

N/A

## Changes

- Extend to all queried name servers: this means that non-queried name servers will not appear, with the exception of name servers of the child or parent zone
- Add classification of name servers ("child", "parent", "other"). Note that name servers shared by the child and parent zone will appear in both categories.
- Add "Count" column as the number of queries sent per name server
- Add "Grand total" row for query times and query count
- Refactoring

## How to test this PR

Run any test with the `--nstimes` option. Check that the formatting is done correctly.

Example output:
```
$ zonemaster-cli --nstimes --raw --no-ipv6 --test basic02 afnic.fr

                     Name servers         Max        Min        Avg     Stddev     Median       Total       Count
=================================  ========== ========== ========== ========== ========== =========== ===========
Child zone ----------------------
          g.ext.nic.fr/194.0.36.1      110.98      33.27      72.88      22.62      69.07     1093.16          15
      g.ext.nic.fr/2001:678:4c::1        0.00       0.00       0.00       0.00       0.00        0.00           0
           ns1.nic.fr/192.134.4.1        4.78       4.78       4.78       0.00       4.78        4.78           1
  ns1.nic.fr/2001:67c:2218:2::4:1        0.00       0.00       0.00       0.00       0.00        0.00           0
            ns2.nic.fr/192.93.0.4        4.82       4.82       4.82       0.00       4.82        4.82           1
  ns2.nic.fr/2001:660:3005:1::1:2        0.00       0.00       0.00       0.00       0.00        0.00           0
          ns3.nic.fr/192.134.0.49        4.96       4.96       4.96       0.00       4.96        4.96           1
  ns3.nic.fr/2001:660:3006:1::1:1        0.00       0.00       0.00       0.00       0.00        0.00           0
Parent zone ---------------------
               d.nic.fr/194.0.9.1      113.08      60.96      87.02      26.06      87.02      174.05           2
           d.nic.fr/2001:678:c::1        0.00       0.00       0.00       0.00       0.00        0.00           0
      f.ext.nic.fr/194.146.106.46        0.00       0.00       0.00       0.00       0.00        0.00           0
f.ext.nic.fr/2001:67c:1010:11::53        0.00       0.00       0.00       0.00       0.00        0.00           0
          g.ext.nic.fr/194.0.36.1      110.98      33.27      72.88      22.62      69.07     1093.16          15
      g.ext.nic.fr/2001:678:4c::1        0.00       0.00       0.00       0.00       0.00        0.00           0
Other ---------------------------
    a.root-servers.net/198.41.0.4      113.63     113.63     113.63       0.00     113.63      113.63           1
  m.root-servers.net/202.12.27.33      110.43       8.39      43.07      21.62      39.96      602.93          14
=================================  ========== ========== ========== ========== ========== =========== ===========
                      Grand total                                                             1998.33          35
```
