### PR TITLE
Expand --count option

### DIFF
--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -672,27 +672,41 @@ sub run {
             }
         }
         else {
-            say __( "\n\n   Level\tNumber of log entries" );
-            say "   =====\t=====================";
+            my $header1 = __( 'Level' );
+            my $header2 = __( 'Number of log entries' );
+            my $max1 = length $header1;
+            my $max2 = length $header2;
+
             foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %counter ) {
-                printf __( "%8s\t%21d\n" ), translate_severity( $level ), $counter{$level};
+                my $len = length translate_severity( $level );
+                $max1 = $len if $len > $max1;
             }
+
+            printf "\n\n%${max1}s\t%${max2}s", $header1, $header2;
+            printf "\n%s\t%s\n", '=' x $max1, '=' x $max2;
+
+            foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %counter ) {
+                printf "%${max1}s\t%${max2}d\n", translate_severity( $level ), $counter{$level};
+            }
+
+            my $header3 = __( 'Message tag' );
+            my $max3 = length $header3;
 
             my %entries;
-            my $max = 1;
             foreach my $e ( @{ Zonemaster::Engine->logger->entries } ) {
                 $entries{$e->level}{$e->tag} += 1;
-                $max = length $e->tag if length $e->tag > $max;
+                my $len = length $e->tag;
+                $max3 = $len if $len > $max3;
             }
 
-            print "\n";
-            printf __("%s \t%${max}s %s\n"), '   Level', 'Message tag', '   Count';
-            printf "%s \t%${max}s %s\n", '   =====', '=' x $max, '   =====';
+            my $header4 = __( 'Count' );
+            my $max4 = max map { length "$_" } ( ( map { values %{ $_ } } ( values %entries ) ), $header4 );
+
+            printf "\n%${max1}s\t%${max3}s\t%${max4}s", $header1, $header3, $header4;
+            printf "\n%${max1}s\t%${max3}s\t%${max4}s\n", '=' x $max1, '=' x $max3, '=' x $max4;
             foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %entries ) {
                 foreach my $tag ( sort keys %{ $entries{$level} } ) {
-                    printf "%8s\t", $level;
-                    printf "%${max}s ", $tag;
-                    printf "%8s\n", $entries{$level}{$tag};
+                    printf "%${max1}s\t%${max3}s\t%${max4}s\n", $level, $tag, $entries{$level}{$tag};
                 }
             }
         }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -675,7 +675,25 @@ sub run {
             say __( "\n\n   Level\tNumber of log entries" );
             say "   =====\t=====================";
             foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %counter ) {
-                printf __( "%8s\t%5d entries.\n" ), translate_severity( $level ), $counter{$level};
+                printf __( "%8s\t%21d\n" ), translate_severity( $level ), $counter{$level};
+            }
+
+            my %entries;
+            my $max = 1;
+            foreach my $e ( @{ Zonemaster::Engine->logger->entries } ) {
+                $entries{$e->level}{$e->tag} += 1;
+                $max = length $e->tag if length $e->tag > $max;
+            }
+
+            print "\n";
+            printf __("%s \t%${max}s %s\n"), '   Level', 'Message tag', '   Count';
+            printf "%s \t%${max}s %s\n", '   =====', '=' x $max, '   =====';
+            foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %entries ) {
+                foreach my $tag ( sort keys %{ $entries{$level} } ) {
+                    printf "%8s\t", $level;
+                    printf "%${max}s ", $tag;
+                    printf "%8s\n", $entries{$level}{$tag};
+                }
             }
         }
     }

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -701,7 +701,7 @@ sub run {
             }
 
             my $header3 = __( 'Message tag' );
-            my $max3 = max map { length "$_" } ( ( map { keys %{ $_ } } ( values %entries ) ), $header3 );;
+            my $max3 = max map { length "$_" } ( ( map { keys %{ $_ } } ( values %entries ) ), $header3 );
             my $header4 = __( 'Count' );
             my $max4 = max map { length "$_" } ( ( map { values %{ $_ } } ( values %entries ) ), $header4 );
 

--- a/lib/Zonemaster/CLI.pm
+++ b/lib/Zonemaster/CLI.pm
@@ -665,16 +665,27 @@ sub run {
     my $json_output = {};
 
     if ( $opt_count ) {
+        my %entries;
+        foreach my $e ( @{ Zonemaster::Engine->logger->entries } ) {
+            $entries{$e->level}{$e->tag} += 1;
+        }
+
         if ( $opt_json ) {
             $json_output->{count} = {};
             foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %counter ) {
-                $json_output->{count}{$level} = $counter{$level};
+                $json_output->{count}{by_level}{$level} = $counter{$level};
+            }
+
+            foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %entries ) {
+                foreach my $tag ( sort keys %{ $entries{$level} } ) {
+                    $json_output->{count}{by_message_tag}{$level}{$tag} = $entries{$level}{$tag};
+                }
             }
         }
         else {
             my $header1 = __( 'Level' );
-            my $header2 = __( 'Number of log entries' );
             my $max1 = length $header1;
+            my $header2 = __( 'Number of log entries' );
             my $max2 = length $header2;
 
             foreach my $level ( sort { $numeric{$b} <=> $numeric{$a} } keys %counter ) {
@@ -690,15 +701,7 @@ sub run {
             }
 
             my $header3 = __( 'Message tag' );
-            my $max3 = length $header3;
-
-            my %entries;
-            foreach my $e ( @{ Zonemaster::Engine->logger->entries } ) {
-                $entries{$e->level}{$e->tag} += 1;
-                my $len = length $e->tag;
-                $max3 = $len if $len > $max3;
-            }
-
+            my $max3 = max map { length "$_" } ( ( map { keys %{ $_ } } ( values %entries ) ), $header3 );;
             my $header4 = __( 'Count' );
             my $max4 = max map { length "$_" } ( ( map { values %{ $_ } } ( values %entries ) ), $header4 );
 

--- a/script/zonemaster-cli
+++ b/script/zonemaster-cli
@@ -250,7 +250,7 @@ Print the name of the test case (test case identifier) which produced the messag
 =item B<--[no-]count>
 
 Print a summary, at the end of a run, of the numbers of messages for each severity
-level that were logged during the run.
+level that were logged during the run, as well as a count of each message tag.
 (default: disabled)
 
 =item B<--[no-]nstimes>

--- a/t/usage.t
+++ b/t/usage.t
@@ -369,6 +369,11 @@ do {
             INFO \s+ \d+
             .*
             DEBUG \s+ \d+
+            .*
+            Level \s+ \QMessage tag\E \s+ \QCount\E
+            .*
+            INFO \s+ \w+ \s+ \d+
+            .*
         }msx,
         json => {
             type       => "object",


### PR DESCRIPTION

## Purpose

This PR proposes an update to the `--count` option.

## Context

N/A

## Changes

- Add a count of each message tag for each severity level
- Dynamically format the table as to support translated strings (e.g. headers and levels)

## How to test this PR

Run any test with the `--count` option. Check that the formatting is done correctly.
Output:
```
$ zonemaster-cli --count --raw --no-ipv6 --test basic02 afnic.fr


 Level  Number of log entries
======  =====================
  INFO                      2
 DEBUG                     53
DEBUG2                    178
DEBUG3                     65

 Level            Message tag   Count
======  =====================   =====
  INFO  B02_AUTH_RESPONSE_SOA       1
  INFO         GLOBAL_VERSION       1
 DEBUG     DEPENDENCY_VERSION       9
 DEBUG         EXTERNAL_QUERY      30
 DEBUG           IPV4_ENABLED       4
 DEBUG          IPV6_DISABLED       4
 DEBUG             MODULE_END       1
 DEBUG         MODULE_VERSION       1
 DEBUG             START_TIME       1
 DEBUG          TEST_CASE_END       1
 DEBUG        TEST_CASE_START       1
 DEBUG            TEST_TARGET       1
DEBUG2          CACHE_CREATED       7
DEBUG2           IPV6_BLOCKED      28
DEBUG2            IS_REDIRECT      14
DEBUG2             NS_CREATED      38
DEBUG2                  QUERY      35
DEBUG2          RECURSE_QUERY      56
DEBUG3          CACHED_RETURN      35
DEBUG3      EXTERNAL_RESPONSE      30
```

Also run it with the `--json` option, and check that the output is correct:
```
$ zonemaster-cli --count --json --raw --no-ipv6 --test basic02 afnic.fr | jq
{
  "count": {
    "by_level": {
      "DEBUG": 53,
      "DEBUG2": 178,
      "DEBUG3": 65,
      "INFO": 2
    },
    "by_message_tag": {
      "DEBUG": {
        "DEPENDENCY_VERSION": 9,
        "EXTERNAL_QUERY": 30,
        "IPV4_ENABLED": 4,
        "IPV6_DISABLED": 4,
        "MODULE_END": 1,
        "MODULE_VERSION": 1,
        "START_TIME": 1,
        "TEST_CASE_END": 1,
        "TEST_CASE_START": 1,
        "TEST_TARGET": 1
      },
      "DEBUG2": {
        "CACHE_CREATED": 7,
        "IPV6_BLOCKED": 28,
        "IS_REDIRECT": 14,
        "NS_CREATED": 38,
        "QUERY": 35,
        "RECURSE_QUERY": 56
      },
      "DEBUG3": {
        "CACHED_RETURN": 35,
        "EXTERNAL_RESPONSE": 30
      },
      "INFO": {
        "B02_AUTH_RESPONSE_SOA": 1,
        "GLOBAL_VERSION": 1
      }
    }
  },
  "results": []
}
```