### PR TITLE
Tidy French translation file

### DIFF
--- a/share/fr.po
+++ b/share/fr.po
@@ -32,8 +32,9 @@ msgstr ""
 "\n"
 
 msgid "Warning: deprecated --encoding, simply remove it from your usage."
-msgstr "Attention : --encoding est dépréciée, retirez-le simplement de "
-"votre ligne de commande."
+msgstr ""
+"Attention : --encoding est dépréciée, retirez-le simplement de votre ligne "
+"de commande."
 
 msgid "Error: --json-stream and --no-json cannot be used together."
 msgstr ""
@@ -72,8 +73,8 @@ msgid ""
 "Error: Invalid input '{cli_arg}' in --test. There must be at most one slash "
 "('/') character."
 msgstr ""
-"Erreur : Saisie incorrecte '{cli_arg}' pour --test. Il doit y avoir au "
-"plus un caractère slash ('/')."
+"Erreur : Saisie incorrecte '{cli_arg}' pour --test. Il doit y avoir au plus "
+"un caractère slash ('/')."
 
 #, perl-brace-format
 msgid ""


### PR DESCRIPTION
## Purpose

This PR fixes a failing unit test by running `make POFILES=fr.po tidy-po` on the French translation file.

## Context

Follow-up to #422 

## Changes

- Tidy `fr.po`

## How to test this PR

Unit tests should now pass, in particular `t/po-files.t`:
```
$ prove t/po-files.t
t/po-files.t .. 1/?     # Using msgcat version: msgcat (GNU gettext-tools) 0.21
t/po-files.t .. ok
All tests successful.
Files=1, Tests=3,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.09 cusr  0.00 csys =  0.10 CPU)
Result: PASS
```
