### PR TITLE
Fixes issue with locale in unit tests

### DIFF
--- a/t/usage.t
+++ b/t/usage.t
@@ -19,6 +19,14 @@ use Test::Differences;
 use Zonemaster::CLI;
 use JSON::Validator;
 
+# Force locale C for these unit tests. They depend on the print outs not being
+# translated. See zonemaster/zonemaster-cli/issues/438 and
+# https://github.com/zonemaster/zonemaster-cli/issues/438#issuecomment-2996235684
+$ENV{LC_ALL} = "C.UTF-8";
+delete $ENV{LANG};
+delete $ENV{LANGUAGE};
+
+
 # CONSTANTS
 
 Readonly::Array my @SIG_NAMES => do {


### PR DESCRIPTION
## Purpose

This PR fixes the issue reported in #438 and https://github.com/zonemaster/zonemaster-cli/issues/438#issuecomment-2996235684

## How to test this PR

Run the unit tests with other locale than "en" or "C" and the unit tests should pass, e.g.

* LC_ALL=da_DK.UTF-8 cpanm -v --test-only Zonemaster-CLI-*.tar.gz # Using a dist file
* LC_ALL=da_DK.UTF-8 cpanm -v --test-only Zonemaster::CLI