### PR TITLE
Make dist generate MO files for inclusion in the dist file.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,6 +54,11 @@ sub MY::postamble {
 
     my $docker = <<'END_DOCKER';
 
+.PHONY: mydist
+mydist:
+	$(MAKE) -C share mo
+	$(MAKE) tardist
+
 docker-build:
 	docker build --tag zonemaster/cli:local --build-arg version=$(VERSION) .
 
@@ -72,5 +77,7 @@ END_DOCKER
 
 install_script 'zonemaster-cli';
 install_share;
+
+makemaker_args( macro => { DIST_DEFAULT => 'mydist' } );
 
 WriteAll;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,8 +23,8 @@ requires(
     'JSON::XS'           => 0,
     'Locale::TextDomain' => 1.23,
     'Try::Tiny'          => 0,
-    'Zonemaster::LDNS'   => 5.000000,  # v5.0.0
-    'Zonemaster::Engine' => 8.000000,  # v8.0.0
+    'Zonemaster::LDNS'   => 5.000000,    # v5.0.0
+    'Zonemaster::Engine' => 8.000000,    # v8.0.0
 );
 
 test_requires(
@@ -34,46 +34,35 @@ test_requires(
 
 # Make all platforms include inc/Module/Install/External.pm
 requires_external_bin 'find';
-if ($^O eq "freebsd") {
+if ( $^O eq "freebsd" ) {
     requires_external_bin 'gmake';
-};
+}
 
 sub MY::postamble {
-    my $pure_all;
-    my $sharemakefile = 'share/GNUmakefile';
-    if ($^O eq "freebsd") {
-        # Make FreeBSD use gmake for share
-        $pure_all = "GMAKE ?= \"gmake\"\n"
-            . "pure_all :: $sharemakefile\n"
-            . "\tcd share && \$(GMAKE) all\n";
-    } else {
-        # Here Linux and GNU Make is assumed
-        $pure_all = "pure_all :: $sharemakefile\n"
-            . "\tcd share && \$(MAKE) all\n";
-    };
+    return <<'MAKE_END';
 
-    my $docker = <<'END_DOCKER';
+pure_all :: share/GNUmakefile
+	$(MAKE) -C share all
+
+.PHONY: docker-build
+docker-build:
+	docker build --tag zonemaster/cli:local --build-arg version=$(VERSION) .
+
+.PHONY: docker-tag-version
+docker-tag-version:
+	docker tag zonemaster/cli:local zonemaster/cli:$(VERSION)
+
+.PHONY: docker-tag-latest
+docker-tag-latest:
+	docker tag zonemaster/cli:local zonemaster/cli:latest
 
 .PHONY: mydist
 mydist:
 	$(MAKE) -C share mo
 	$(MAKE) tardist
 
-docker-build:
-	docker build --tag zonemaster/cli:local --build-arg version=$(VERSION) .
-
-docker-tag-version:
-	docker tag zonemaster/cli:local zonemaster/cli:$(VERSION)
-
-docker-tag-latest:
-	docker tag zonemaster/cli:local zonemaster/cli:latest
-
-END_DOCKER
-
-    return $pure_all . $docker;
-};
-
-
+MAKE_END
+} ## end sub MY::postamble
 
 install_script 'zonemaster-cli';
 install_share;

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -15,6 +15,9 @@ tidy-po:
 	trap 'rm -rf "$$tmpdir"' EXIT ;\
 	for f in $(POFILES) ; do msgcat $$f -o $$tmpdir/$$f && mv -f $$tmpdir/$$f $$f  ; done
 
+.PHONY: mo
+mo: $(MOFILES)
+
 update-po: extract-pot
 	@for f in $(POFILES) ; do msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $$f $(POTFILE) ; done
 


### PR DESCRIPTION
## Purpose

This PR updates `make dist` to generate the MO files before creating the tarball.
As a drive-by, some clean-up is also performed on `Makefile.PL`.

## Context

Fixes #442.

## Changes

* Add a dedicated make target `make -C share mo` to only generate all MO files.
* Make `make dist` depend on `make -C share mo`. Maybe there are simpler and better ways to achieve this, but the best I could come up with was:
   1. Add a new target `make mydist` that runs both `make -C share mo` and `make tardist` in that order.
   2. Override DIST_DEFAULT from `tardist` to `mydist`.
* Clean-ups in Makefile.PL:
  * Avoid reimplementing the share/Makefile mechanism
  * Use `make -C share` instead of `cd share && make`
  * Declare phony targets as such
  * Tidy Makefile.PL according to .perltidyrc

## Testing
I tested this by executing the following and verifying that all of the MO files were listed.

```sh
rm -f Zonemaster-CLI-*.tar.gz && git clean -dfx && perl Makefile.PL && make dist && clear && tar tvf Zonemaster-CLI-*.tar.gz | grep mo
```

I have not tested this on FreeBSD. My hypothesis is that the share/Makefile mechanism is able switch to gmake on FreeBSD, but I haven't actually tested it.