### PR TITLE
Add artifact build to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         run: sudo apt-get install -y build-essential git libmodule-install-perl
 
       - name: build
-        run: perl Makefile.PL && make dist
+        run: perl Makefile.PL && make all dist
 
       - name: Get short SHA
         id: short_sha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,33 @@ jobs:
       - name: Test
         run: |
           prove -lv t
+
+  build-artifact:
+    needs: run-tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: apt install
+        run: sudo apt-get install -y build-essential git libmodule-install-perl
+
+      - name: build
+        run: perl Makefile.PL && make dist
+
+      - name: Get short SHA
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Get Zonemaster-CLI version
+        id: version
+        run: |
+          result=`grep "use version; our $VERSION" lib/Zonemaster/CLI.pm`
+          result+='printf $VERSION;'
+          VERSION=`perl -e "$result"`
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Zonemaster-CLI-${{ steps.version.outputs.version }}-${{ steps.short_sha.outputs.short_sha }}
+          path: Zonemaster-CLI-${{ steps.version.outputs.version }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,12 @@ jobs:
 
       - name: Get short SHA
         id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: |
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+                echo "SHORT_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_ENV
+            else
+                echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+            fi
 
       - name: Get Zonemaster-CLI version
         id: version
@@ -138,5 +143,5 @@ jobs:
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Zonemaster-CLI-${{ steps.version.outputs.version }}-${{ steps.short_sha.outputs.short_sha }}
+          name: Zonemaster-CLI-${{ steps.version.outputs.version }}-${{ env.SHORT_SHA }}
           path: Zonemaster-CLI-${{ steps.version.outputs.version }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: apt install
-        run: sudo apt-get install -y build-essential git libmodule-install-perl
+        run: sudo apt-get install -y build-essential git libmodule-install-perl gettext
 
       - name: build
         run: perl Makefile.PL && make all dist

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ Additional end-user documentation is available in the [USING] document.
 
 When developing Zonemaster-CLI, refer to the [development documentation].
 
+## CI artifact
+
+A tarball (`Zonemaster-CLI-<version>.tar.gz`) is built and uploaded as a GitHub Actions artifact on every push and pull request. This artifact can be useful for release testing and PR review.
+To download it:
+1. Go to the [Actions tab](https://github.com/zonemaster/zonemaster-cli/actions) of the repository.
+2. Select a workflow run (e.g. for a specific PR or branch).
+3. Scroll to the bottom of the run summary to the **Artifacts** section.
+4. Download the artifact named `Zonemaster-CLI-<version>-<short_sha>`.
+The artifact name includes the module version and the first 7 characters of the commit SHA.
 
 ## Participation, Contact and Bug reporting
 


### PR DESCRIPTION
## Purpose

This PR adds artifact creation to CI. This artifact can be useful for release testing and PR review.
The artifact is created only if all tests pass.

## Context

Follow-up to https://github.com/zonemaster/zonemaster-backend/issues/1229

## How to test this PR

You should be able to download the artifact from the action tab and install it by following the Zonemaster documentation.
https://doc.zonemaster.fr/latest/installation/README.html
