### PR TITLE
Docker build: fix for Net-IDN-Encode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apk add --no-cache \
     perl-test-deep \
     perl-test-differences \
     perl-try-tiny \
+    build-base perl-test-nowarnings perl-dev \
+ && cpanm --notest --no-wget --from https://cpan.metacpan.org/ \
+    https://cpan.metacpan.org/authors/id/E/ET/ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz \
  && cpanm --notest --no-wget --from https://cpan.metacpan.org/ \
     JSON::Validator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM zonemaster/engine:local AS build
 
 RUN apk add --no-cache \
+    build-base \
     make \
     perl-app-cpanminus \
+    perl-dev \
     perl-json-xs \
     perl-lwp-protocol-https \
     perl-mojolicious \
     perl-test-deep \
     perl-test-differences \
+    perl-test-nowarnings \
     perl-try-tiny \
-    build-base perl-test-nowarnings perl-dev \
  && cpanm --notest --no-wget --from https://cpan.metacpan.org/ \
     https://cpan.metacpan.org/authors/id/E/ET/ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz \
  && cpanm --notest --no-wget --from https://cpan.metacpan.org/ \


### PR DESCRIPTION
## Purpose

Fix Docker image build failure caused by `Net::IDN::Encode` no longer
compiling with current toolchain versions.

## Context

The upstream `Net::IDN::Encode` module has not been updated since
January 2022 and fails to build from source in the current Alpine-based
Docker image. A community-provided fix exists in
[cfaerber/Net-IDN-Encode#11](https://github.com/cfaerber/Net-IDN-Encode/pull/11),
and a trial release incorporating the fix is available on CPAN:
[Net-IDN-Encode-2.501-TRIAL](https://cpan.metacpan.org/authors/id/E/ET/ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz).

I ran a quick AI check on [the proposed fix](https://cpan.metacpan.org/authors/id/E/ET/ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz) and it doesnt find suspicious or malicious code.


## Changes

- Add build dependencies (`build-base`, `perl-test-nowarnings`, `perl-dev`)
  required to compile `Net::IDN::Encode` from source.
- Install `Net-IDN-Encode-2.501-TRIAL` from CPAN before the remaining
  `cpanm` dependencies, so that the patched version satisfies any
  downstream requirements.

## How to test this PR

The docker image build should complete without errors. Optionally verify the module
loads correctly:
```sh
❯ docker run --rm -ti  --entrypoint /bin/sh zonemaster/cli:local
~ $ perl -MNet::IDN::Encode -e 'print "OK\n"'
OK
``

