### PR TITLE
CI: force update (CLI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           perl-version: ${{ matrix.perl }}
 
+      - name: update
+        run: sudo apt update -y
+
       - name: Install binary dependencies
         run: |
           # * These were taken from the installation instruction.
@@ -117,6 +120,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: update
+        run: sudo apt update -y
+ 
       - name: apt install
         run: sudo apt-get install -y build-essential git libmodule-install-perl gettext
 


### PR DESCRIPTION
## Purpose
This PR adds a forced apt update step to the CI workflow to work around a bug causing stale package lists on GitHub Actions runners, which was blocking other PRs from passing CI.

## Context
https://github.com/zonemaster/zonemaster-engine/pull/1533 was failing CI due to `apt-get install` errors caused by outdated package lists on the runner. The runner's cached package index appears to reference packages that are no longer available in the repositories, leading to errors during dependency installation.

# Changes
Added a `sudo apt update -y` step in `.github/workflows/ci.yml` before the package installation steps in two jobs:
- Before the "Binary dependencies" step in the main test job
- Before the "apt install" step in the build-artifact job

This forces a refresh of the apt package index at the start of each job, ensuring that subsequent apt-get install commands reference up-to-date package URLs.

## How to test this PR
- Verify that all CI jobs pass (especially build-artifact)
- Confirm that apt-get install steps no longer fail

